### PR TITLE
Feat: Member 엔티티 구현

### DIFF
--- a/src/main/java/org/example/spring/constants/Gender.java
+++ b/src/main/java/org/example/spring/constants/Gender.java
@@ -1,0 +1,5 @@
+package org.example.spring.constants;
+
+public enum Gender {
+    MALE, FEMALE, NON_BINARY
+}

--- a/src/main/java/org/example/spring/domain/Member.java
+++ b/src/main/java/org/example/spring/domain/Member.java
@@ -1,0 +1,66 @@
+package org.example.spring.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.spring.constants.Gender;
+import org.hibernate.annotations.ColumnDefault;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
+    private Long id;
+
+    @Column(name = "email", nullable = false, length = 100)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 100)
+    private String nickname;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "phone_number", nullable = false, length = 100)
+    private String phoneNumber;
+
+    @Enumerated
+    @Column(name = "gender", nullable = false)
+    private Gender gender;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @Column(name = "last_login_date", nullable = false)
+    private Instant lastLoginDate;
+
+    @ColumnDefault("false")
+    @Column(name = "email_verified", nullable = false)
+    private Boolean emailVerified;
+
+    @ColumnDefault("false")
+    @Column(name = "otp_verified", nullable = false)
+    private Boolean otpVerified;
+
+}


### PR DESCRIPTION
## 📝 PR 설명

Member 엔티티를 구현하고 빌더 패턴 사용을 강제하며 JPA 호환성을 보장하기 위한 설정을 추가했습니다.

## 🛠 변경 사항

- ✨ Member 엔티티 클래스 구현
- 🔧 빌더 패턴 사용 강제 및 JPA 호환성 보장을 위한 설정 추가
- Gender ENUM 클래스 추가

  - @ Builder 어노테이션 적용
  - @ AllArgsConstructor(access = AccessLevel.PRIVATE) 설정으로 전체 인자 생성자를 private으로 제한
  - @ NoArgsConstructor(access = AccessLevel.PROTECTED) 설정으로 기본 생성자를 protected로 설정

## 🔍 테스트

N/A

## 📸 스크린샷 (선택사항)

N/A

## 🔗 관련 이슈
Relates to #9 

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트
N/A