### PR TITLE
Feat: MemberController 회원가입 엔드포인트 구현 및 ci test 관련 오류 수정

### DIFF
--- a/.github/workflows/Spring CI.yml
+++ b/.github/workflows/Spring CI.yml
@@ -17,8 +17,6 @@ jobs:
       RDS_PASSWORD: ${{ secrets.RDS_PASSWORD }}
       SECURITY_USER_NAME: ${{ secrets.SECURITY_USER_NAME }}
       SECURITY_USER_PASSWORD: ${{ secrets.SECURITY_USER_PASSWORD }}
-      LANG: ko_KR.UTF-8
-      LC_ALL: ko_KR.UTF-8
 
     steps:
       - name: Check out code
@@ -29,6 +27,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+
       - name: Setup MySQL
         uses: samin/mysql-action@v1
         with:
@@ -37,22 +36,19 @@ jobs:
           database: ${{ secrets.RDS_NAME }}
           user: ${{ secrets.RDS_USER }}
           password: ${{ secrets.RDS_PASSWORD }}
-          character set server: 'utf8'
+          character set server: 'utf8mb4'
+          collation server: 'utf8mb4_unicode_ci'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew build
-
-      - name: Run tests
-        run: ./gradlew test --info --stacktrace
+      - name: Build and test with Gradle
+        run: ./gradlew build test --debug
 
   dependency-submission:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -60,6 +56,5 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0

--- a/.github/workflows/Spring CI.yml
+++ b/.github/workflows/Spring CI.yml
@@ -42,8 +42,11 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build and test with Gradle
-        run: ./gradlew build test --info
-
+        run: |
+          ./gradlew build test --info || (
+            echo "Tests failed. Rerunning failed tests with debug logging:"
+            ./gradlew test --info -Dtest.single=* -Dtest.debug --tests `grep -h -r "FAILED" build/test-results/test/TEST-*.xml | sed -E "s/.*classname='(.*)'.*/\1/"`
+          )
   dependency-submission:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/Spring CI.yml
+++ b/.github/workflows/Spring CI.yml
@@ -44,7 +44,7 @@ jobs:
         run: ./gradlew build
 
       - name: Run tests
-        run: ./gradlew test
+        run: ./gradlew test --info --stacktrace
 
   dependency-submission:
     runs-on: ubuntu-latest

--- a/.github/workflows/Spring CI.yml
+++ b/.github/workflows/Spring CI.yml
@@ -17,6 +17,8 @@ jobs:
       RDS_PASSWORD: ${{ secrets.RDS_PASSWORD }}
       SECURITY_USER_NAME: ${{ secrets.SECURITY_USER_NAME }}
       SECURITY_USER_PASSWORD: ${{ secrets.SECURITY_USER_PASSWORD }}
+      LANG: ko_KR.UTF-8
+      LC_ALL: ko_KR.UTF-8
 
     steps:
       - name: Check out code

--- a/.github/workflows/Spring CI.yml
+++ b/.github/workflows/Spring CI.yml
@@ -31,11 +31,10 @@ jobs:
       - name: Setup MySQL
         uses: samin/mysql-action@v1
         with:
-          host: ${{ secrets.RDS_HOST }}
-          port: ${{ secrets.RDS_PORT }}
-          database: ${{ secrets.RDS_NAME }}
-          user: ${{ secrets.RDS_USER }}
-          password: ${{ secrets.RDS_PASSWORD }}
+          host port: ${{ secrets.RDS_PORT }}
+          mysql database: ${{ secrets.RDS_NAME }}
+          mysql user: ${{ secrets.RDS_USER }}
+          mysql password: ${{ secrets.RDS_PASSWORD }}
           character set server: 'utf8mb4'
           collation server: 'utf8mb4_unicode_ci'
 
@@ -43,7 +42,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build and test with Gradle
-        run: ./gradlew build test --debug
+        run: ./gradlew build test --info
 
   dependency-submission:
     runs-on: ubuntu-latest

--- a/src/main/java/org/example/spring/common/ApiResponseDto.java
+++ b/src/main/java/org/example/spring/common/ApiResponseDto.java
@@ -1,0 +1,55 @@
+package org.example.spring.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * API 응답을 위한 공통 DTO 클래스입니다.
+ *
+ * @param <T> 응답 데이터의 타입
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class ApiResponseDto<T> {
+
+    /**
+     * API 응답 메세지.
+     * 주로 요청 처리 결과에 대한 설명이나 오류 메세지를 포함합니다.
+     */
+    private String message;
+
+    /**
+     * API 응답 데이터
+     * 요청에 대한 실제 데이터를 포함합니다. 데이터의 타입은 제네릭 파라미터에 의해 결정됩니다.
+     */
+    private T data;
+
+    /**
+     * 성공 응답을 생성합니다.
+     *
+     * @param <T> 응답 데이터의 데이터 타입
+     * @param message 성공 메세지
+     * @param data 응답 데이터
+     * @return 성공 응답 DTO
+     */
+    public static <T> ApiResponseDto<T> success(String message, T data) {
+        return new ApiResponseDto<>(message, data);
+    }
+
+    /**
+     * 오류 응답을 생성합니다.
+     *
+     * @param message 오류 메세지
+     * @return 오류 응답 DTO
+     */
+    public static ApiResponseDto<Void> error(String message) {
+        return new ApiResponseDto<>(message, null);
+    }
+}

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -1,7 +1,13 @@
 package org.example.spring.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.spring.domain.member.Member;
+import org.example.spring.domain.member.dto.MemberJoinRequestDto;
 import org.example.spring.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,5 +18,9 @@ public class MemberController {
 
     private final MemberService memberService;
 
-
+    @PostMapping("/join")
+    public ResponseEntity<String> registerMember(@RequestBody MemberJoinRequestDto memberJoinRequestDto) {
+        memberService.registerMember(memberJoinRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입에 성공했습니다.");
+    }
 }

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -2,11 +2,13 @@ package org.example.spring.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.member.Member;
 import org.example.spring.domain.member.dto.MemberJoinRequestDto;
 import org.example.spring.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,15 +23,24 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
-    public ResponseEntity<String> registerMember(@RequestBody MemberJoinRequestDto memberJoinRequestDto) {
-        try {
-            memberService.registerMember(memberJoinRequestDto);
-            return ResponseEntity.status(HttpStatus.CREATED).body("회원가입에 성공했습니다.");
-        } catch (IllegalArgumentException ex) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
-        } catch (Exception ex) {
-            log.error("회원가입 중 오류 발생", ex);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류가 발생했습니다.");
-        }
+    public ResponseEntity<ApiResponseDto<String>> registerMember(@RequestBody MemberJoinRequestDto memberJoinRequestDto) {
+        Member member = memberService.registerMember(memberJoinRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponseDto.success("회원가입에 성공했습니다.", member.getNickname()));
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponseDto.error("회원가입에 실패했습니다: " + e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleException(Exception e) {
+        log.error("서버 오류 발생", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponseDto.error("서버 오류가 발생했습니다."));
+    }
+
+
 }

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -1,6 +1,7 @@
 package org.example.spring.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.spring.domain.member.Member;
 import org.example.spring.domain.member.dto.MemberJoinRequestDto;
 import org.example.spring.service.MemberService;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
+@Slf4j
 public class MemberController {
 
     private final MemberService memberService;
@@ -23,8 +25,11 @@ public class MemberController {
         try {
             memberService.registerMember(memberJoinRequestDto);
             return ResponseEntity.status(HttpStatus.CREATED).body("회원가입에 성공했습니다.");
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
         } catch (Exception ex) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("회원가입에 실패했습니다.");
+            log.error("회원가입 중 오류 발생", ex);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류가 발생했습니다.");
         }
     }
 }

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -20,7 +20,11 @@ public class MemberController {
 
     @PostMapping("/join")
     public ResponseEntity<String> registerMember(@RequestBody MemberJoinRequestDto memberJoinRequestDto) {
-        memberService.registerMember(memberJoinRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입에 성공했습니다.");
+        try {
+            memberService.registerMember(memberJoinRequestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body("회원가입에 성공했습니다.");
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("회원가입에 실패했습니다.");
+        }
     }
 }

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -1,0 +1,16 @@
+package org.example.spring.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.spring.service.MemberService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+
+}

--- a/src/test/java/org/example/spring/controller/MemberControllerTest.java
+++ b/src/test/java/org/example/spring/controller/MemberControllerTest.java
@@ -17,16 +17,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+@SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
-@WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest {
 
     @Autowired
@@ -90,7 +90,7 @@ class MemberControllerTest {
                 .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
             .andExpect(status().isInternalServerError())
             .andExpect(jsonPath("$.message").value("서버 오류가 발생했습니다. 나중에 다시 시도해주세요."))
-            .andExpect(jsonPath("$.data").isEmpty());
+            .andExpect(jsonPath("$.data").doesNotExist());
     }
 
     @Test
@@ -104,8 +104,8 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.message").value("회원가입에 실패했습니다: 잘못된 요청입니다."))
-            .andExpect(jsonPath("$.data").isEmpty());
+            .andExpect(jsonPath("$.message").value("회원가입에 실패했습니다: " + errorMessage))
+            .andExpect(jsonPath("$.data").doesNotExist());
     }
 
 }

--- a/src/test/java/org/example/spring/controller/MemberControllerTest.java
+++ b/src/test/java/org/example/spring/controller/MemberControllerTest.java
@@ -1,0 +1,110 @@
+package org.example.spring.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.spring.common.ApiResponseDto;
+import org.example.spring.constants.Gender;
+import org.example.spring.domain.member.Member;
+import org.example.spring.domain.member.MemberRole;
+import org.example.spring.domain.member.dto.MemberJoinRequestDto;
+import org.example.spring.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MemberJoinRequestDto memberJoinRequestDto;
+
+    @BeforeEach
+    void setUp() {
+        memberJoinRequestDto = MemberJoinRequestDto.builder()
+            .email("test@example.com")
+            .password("Password1!")
+            .nickname("testuser")
+            .name("Test User")
+            .phoneNumber("010-1234-5678")
+            .gender(Gender.MALE)
+            .build();
+    }
+
+    @Test
+    @DisplayName("회원 가입 성공 테스트")
+    void registerMember_Success() throws Exception {
+        Member savedMember = Member.builder()
+            .id(1L)
+            .name(memberJoinRequestDto.getName())
+            .email(memberJoinRequestDto.getEmail())
+            .nickname(memberJoinRequestDto.getNickname())
+            .password(memberJoinRequestDto.getPassword())
+            .phoneNumber(memberJoinRequestDto.getPhoneNumber())
+            .gender(memberJoinRequestDto.getGender())
+            .role(MemberRole.USER)
+            .build();
+
+        when(memberService.registerMember(any(MemberJoinRequestDto.class))).thenReturn(savedMember);
+
+        mockMvc.perform(post("/api/members/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
+            .andExpect(status().isCreated())
+            .andExpect(content().json(objectMapper.writeValueAsString(ApiResponseDto.success("회원가입에 성공했습니다.", savedMember.getNickname()))));
+    }
+
+    @Test
+    @DisplayName("회원 가입 실패 테스트 - 서버 오류")
+    void registerMember_Failure_ServerError() throws Exception {
+        when(memberService.registerMember(any(MemberJoinRequestDto.class)))
+            .thenThrow(new RuntimeException("서버 오류 발생"));
+
+        mockMvc.perform(post("/api/members/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
+            .andExpect(status().isInternalServerError())
+            .andExpect(
+                content().json(objectMapper.writeValueAsString(ApiResponseDto.error("서버 오류가 발생했습니다. 나중에 다시 시도해주세요."))));
+    }
+
+    @Test
+    @DisplayName("회원 가입 실패 테스트 - 잘못된 요청")
+    void registerMember_Failure_BadRequest() throws Exception {
+        String errorMessage = "잘못된 요청입니다.";
+        when(memberService.registerMember(any(MemberJoinRequestDto.class)))
+            .thenThrow(new IllegalArgumentException(errorMessage));
+
+        mockMvc.perform(post("/api/members/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().json(objectMapper.writeValueAsString(ApiResponseDto.error("회원가입에 실패했습니다: " + errorMessage))));
+    }
+
+}

--- a/src/test/java/org/example/spring/controller/MemberControllerTest.java
+++ b/src/test/java/org/example/spring/controller/MemberControllerTest.java
@@ -106,7 +106,7 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
             .andExpect(status().isInternalServerError())
-            .andExpect(jsonPath("$.message").value("서버 오류가 발생했습니다. 나중에 다시 시도해주세요."))
+            .andExpect(jsonPath("$.message").value("서버 오류가 발생했습니다."))
             .andExpect(jsonPath("$.data").doesNotExist())
             .andReturn();
 

--- a/src/test/java/org/example/spring/controller/MemberControllerTest.java
+++ b/src/test/java/org/example/spring/controller/MemberControllerTest.java
@@ -3,11 +3,10 @@ package org.example.spring.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.example.spring.common.ApiResponseDto;
 import org.example.spring.constants.Gender;
 import org.example.spring.domain.member.Member;
 import org.example.spring.domain.member.MemberRole;
@@ -76,7 +75,8 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
             .andExpect(status().isCreated())
-            .andExpect(content().json(objectMapper.writeValueAsString(ApiResponseDto.success("회원가입에 성공했습니다.", savedMember.getNickname()))));
+            .andExpect(jsonPath("$.message").value("회원가입에 성공했습니다."))
+            .andExpect(jsonPath("$.data").value(savedMember.getNickname()));
     }
 
     @Test
@@ -89,8 +89,8 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
             .andExpect(status().isInternalServerError())
-            .andExpect(
-                content().json(objectMapper.writeValueAsString(ApiResponseDto.error("서버 오류가 발생했습니다. 나중에 다시 시도해주세요."))));
+            .andExpect(jsonPath("$.message").value("서버 오류가 발생했습니다. 나중에 다시 시도해주세요."))
+            .andExpect(jsonPath("$.data").isEmpty());
     }
 
     @Test
@@ -104,7 +104,8 @@ class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(memberJoinRequestDto)))
             .andExpect(status().isBadRequest())
-            .andExpect(content().json(objectMapper.writeValueAsString(ApiResponseDto.error("회원가입에 실패했습니다: " + errorMessage))));
+            .andExpect(jsonPath("$.message").value("회원가입에 실패했습니다: 잘못된 요청입니다."))
+            .andExpect(jsonPath("$.data").isEmpty());
     }
 
 }


### PR DESCRIPTION
## 📝 PR 설명

MemberController 의 회원가입 엔드포인트(/join)을 구현하고 테스트 코드를 추가했스빈다.

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

-♻️ MemberController의 회원 가입 메서드 구현
- ✨ 회원 가입시 이메일 중복 체크 기능 추가
- 📚 ApiResponseDto 구현 및 주석 작성
- 🔧 Spring CI.yml 에 로깅 추가

## 🔍 테스트

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [ ] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

N/A

## 🔗 관련 이슈

Closes #23 
Closes #47 

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

N/A