### PR TITLE
Feat/#49 회원 전체 목록 조회 구현

### DIFF
--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -18,6 +18,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 회원 관련 API 엔드포인트를 담당하는 컨트롤러 클래스입니다.
+ * 회원 가입, 회원 목록 조회 등의 기능을 제공합니다.
+ */
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
@@ -26,6 +30,12 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    /**
+     * 새로운 회원을 등록합니다.
+     *
+     * @param memberJoinRequestDto 회원 가입 정보를 담은 DTO
+     * @return 회원 가입 성공 여부 및 생성된 회원 MemberResponseDto
+     */
     @PostMapping("/join")
     public ResponseEntity<ApiResponseDto<String>> registerMember(@RequestBody MemberJoinRequestDto memberJoinRequestDto) {
         Member member = memberService.registerMember(memberJoinRequestDto);
@@ -33,6 +43,13 @@ public class MemberController {
             .body(ApiResponseDto.success("회원가입에 성공했습니다.", member.getNickname()));
     }
 
+    /**
+     * 페이징 처리된 전체 회원 목록을 조회합니다.
+     *
+     * @param page 조회할 페이지 번호
+     * @param size 한 페이지당 표시할 회원 수
+     * @return 페이징된 회원 목록 DTO
+     */
     @GetMapping
     public ResponseEntity<ApiResponseDto<Page<MemberResponseDto>>> getAllMembers(
         @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -5,13 +5,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.member.Member;
 import org.example.spring.domain.member.dto.MemberJoinRequestDto;
+import org.example.spring.domain.member.dto.MemberResponseDto;
 import org.example.spring.service.MemberService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,6 +31,15 @@ public class MemberController {
         Member member = memberService.registerMember(memberJoinRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponseDto.success("회원가입에 성공했습니다.", member.getNickname()));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<Page<MemberResponseDto>>> getAllMembers(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<MemberResponseDto> members = memberService.getAllMembers(page, size);
+        return ResponseEntity.ok(ApiResponseDto.success("회원 목록 조회 성공", members));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/org/example/spring/domain/member/dto/MemberJoinRequestDto.java
+++ b/src/main/java/org/example/spring/domain/member/dto/MemberJoinRequestDto.java
@@ -26,4 +26,16 @@ public class MemberJoinRequestDto {
     String phoneNumber;
     Gender gender;
 
+
+    public static Member toEntity(MemberJoinRequestDto memberJoinRequestDto,
+        String hashedPassword) {
+        return Member.builder()
+            .email(memberJoinRequestDto.getEmail())
+            .password(hashedPassword)
+            .nickname(memberJoinRequestDto.getNickname())
+            .name(memberJoinRequestDto.getName())
+            .phoneNumber(memberJoinRequestDto.getPhoneNumber())
+            .gender(memberJoinRequestDto.getGender())
+            .build();
+    }
 }

--- a/src/main/java/org/example/spring/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/org/example/spring/domain/member/dto/MemberResponseDto.java
@@ -1,0 +1,32 @@
+package org.example.spring.domain.member.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.example.spring.domain.member.Member;
+
+/**
+ * DTO for {@link Member}
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class MemberResponseDto {
+
+    private String email;
+    private String nickname;
+    private String name;
+
+    public static MemberResponseDto toDto(Member member) {
+        return MemberResponseDto.builder()
+            .email(member.getEmail())
+            .nickname(member.getNickname())
+            .name(member.getName())
+            .build();
+    }
+}

--- a/src/main/java/org/example/spring/repository/MemberRepository.java
+++ b/src/main/java/org/example/spring/repository/MemberRepository.java
@@ -4,6 +4,10 @@ import org.example.spring.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+/**
+ * 회원 엔티티의 CRUD 작업을 담당하는 리포지토리 인터페이스입니다.
+ * 회원 정보 저장, 조회, 변경, 삭제 등의 기능을 제공합니다.
+ */
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 

--- a/src/main/java/org/example/spring/service/MemberService.java
+++ b/src/main/java/org/example/spring/service/MemberService.java
@@ -16,6 +16,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 회원 관련 서비스 로직을 담당하는 클래스입니다.
+ * 회원 가입, 회원 목록 조회 등의 기능을 제공합니다.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -40,6 +44,12 @@ public class MemberService {
         }
     }
 
+    /**
+     * 새로운 회원을 등록합니다.
+     *
+     * @param memberJoinRequestDto 회원 가입 정보를 담은 DTO
+     * @return 등록된 회원 MemberResponseDto
+     */
     public Member registerMember(MemberJoinRequestDto memberJoinRequestDto) {
         validateMemberDto(memberJoinRequestDto);
         checkDuplicates(memberJoinRequestDto);
@@ -51,6 +61,13 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
+    /**
+     * 페이징 처리된 전체 회원 목록을 조회합니다.
+     *
+     * @param page 조회할 페이지 번호
+     * @param size 한 페이지당 표시할 회원 수
+     * @return 페이징된 회원 목록 DTO
+     */
     @Transactional(readOnly = true)
     public Page<MemberResponseDto> getAllMembers(int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());

--- a/src/main/java/org/example/spring/service/MemberService.java
+++ b/src/main/java/org/example/spring/service/MemberService.java
@@ -1,16 +1,24 @@
 package org.example.spring.service;
 
-import jakarta.transaction.Transactional;
+import static org.example.spring.domain.member.dto.MemberJoinRequestDto.toEntity;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.example.spring.domain.member.Member;
 import org.example.spring.domain.member.dto.MemberJoinRequestDto;
+import org.example.spring.domain.member.dto.MemberResponseDto;
 import org.example.spring.repository.MemberRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -32,7 +40,6 @@ public class MemberService {
         }
     }
 
-    @Transactional
     public Member registerMember(MemberJoinRequestDto memberJoinRequestDto) {
         validateMemberDto(memberJoinRequestDto);
         checkDuplicates(memberJoinRequestDto);
@@ -44,16 +51,11 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-    private Member toEntity(MemberJoinRequestDto memberJoinRequestDto,
-        String hashedPassword) {
-        return Member.builder()
-            .email(memberJoinRequestDto.getEmail())
-            .password(hashedPassword)
-            .nickname(memberJoinRequestDto.getNickname())
-            .name(memberJoinRequestDto.getName())
-            .phoneNumber(memberJoinRequestDto.getPhoneNumber())
-            .gender(memberJoinRequestDto.getGender())
-            .build();
+    @Transactional(readOnly = true)
+    public Page<MemberResponseDto> getAllMembers(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+        Page<Member> members= memberRepository.findAll(pageable);
+        return members.map(MemberResponseDto::toDto);
     }
 
     private void validateMemberDto(MemberJoinRequestDto memberJoinRequestDto) {

--- a/src/test/java/org/example/spring/controller/MemberControllerTest.java
+++ b/src/test/java/org/example/spring/controller/MemberControllerTest.java
@@ -1,8 +1,12 @@
 package org.example.spring.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -19,16 +23,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
 class MemberControllerTest {
 
@@ -90,6 +94,7 @@ class MemberControllerTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.message").value("회원가입에 성공했습니다."))
             .andExpect(jsonPath("$.data").value(savedMember.getNickname()))
+            .andDo(print())
             .andReturn();
 
         String responseContent = result.getResponse().getContentAsString();
@@ -108,6 +113,7 @@ class MemberControllerTest {
             .andExpect(status().isInternalServerError())
             .andExpect(jsonPath("$.message").value("서버 오류가 발생했습니다."))
             .andExpect(jsonPath("$.data").doesNotExist())
+            .andDo(print())
             .andReturn();
 
         String responseContent = result.getResponse().getContentAsString();
@@ -127,10 +133,32 @@ class MemberControllerTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("회원가입에 실패했습니다: " + errorMessage))
             .andExpect(jsonPath("$.data").doesNotExist())
+            .andDo(print())
             .andReturn();
 
         String responseContent = result.getResponse().getContentAsString();
         System.out.println("Actual response: " + responseContent);
+    }
+
+    @Test
+    @DisplayName("회원 전체 목록 조회 - 페이징")
+    void getAllMembers_no_search() throws Exception {
+        // given
+        given(memberService.getAllMembers(anyInt(), anyInt()))
+            .willReturn(Page.empty());
+
+        // when
+        ResultActions actions = mockMvc.perform(
+            get("/api/members")
+                .param("page", "0")
+                .param("size", "10"));
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("회원 목록 조회 성공"))
+            .andExpect(jsonPath("$.data").isMap())
+            .andDo(print());
     }
 
 }

--- a/src/test/java/org/example/spring/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/example/spring/repository/MemberRepositoryTest.java
@@ -1,8 +1,10 @@
 package org.example.spring.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 import org.example.spring.constants.Gender;
 import org.example.spring.domain.member.Member;
@@ -14,12 +16,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @Transactional
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@ActiveProfiles("test")
 class MemberRepositoryTest {
 
     @Autowired
@@ -42,7 +45,6 @@ class MemberRepositoryTest {
     void saveMember() {
 
         Member savedMember = memberRepository.save(testMember);
-
 
         assertThat(savedMember).isNotNull();
         assertThat(savedMember.getId()).isNotNull();
@@ -101,6 +103,53 @@ class MemberRepositoryTest {
 
         boolean notExists = memberRepository.existsByPhoneNumber("010-9999-9999");
         assertThat(notExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원 전체 조회 테스트")
+    void findAll() {
+        // given
+        Member member1 = Member.builder()
+            .name("Member 1")
+            .email("member1@example.com")
+            .nickname("member1")
+            .password("password123!")
+            .phoneNumber("010-1234-5678")
+            .gender(Gender.MALE)
+            .role(MemberRole.USER)
+            .build();
+        Member member2 = Member.builder()
+            .name("Member 2")
+            .email("member2@example.com")
+            .nickname("member2")
+            .password("password123!")
+            .phoneNumber("010-2345-6789")
+            .gender(Gender.FEMALE)
+            .role(MemberRole.USER)
+            .build();
+        Member member3 = Member.builder()
+            .name("Member 3")
+            .email("member3@example.com")
+            .nickname("member3")
+            .password("password123!")
+            .phoneNumber("010-3456-7890")
+            .gender(Gender.MALE)
+            .role(MemberRole.USER)
+            .build();
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        // when
+        Page<Member> result = memberRepository.findAll(Pageable.unpaged());
+
+        // then
+        assertThat(result.getContent())
+            .hasSize(3)
+            .extracting("name", "email", "nickname", "gender", "role")
+            .containsExactlyInAnyOrder(
+                tuple("Member 1", "member1@example.com", "member1", Gender.MALE, MemberRole.USER),
+                tuple("Member 2", "member2@example.com", "member2", Gender.FEMALE, MemberRole.USER),
+                tuple("Member 3", "member3@example.com", "member3", Gender.MALE, MemberRole.USER)
+            );
     }
 
 }

--- a/src/test/java/org/example/spring/service/MemberServiceTest.java
+++ b/src/test/java/org/example/spring/service/MemberServiceTest.java
@@ -3,6 +3,8 @@ package org.example.spring.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +12,7 @@ import org.example.spring.constants.Gender;
 import org.example.spring.domain.member.Member;
 import org.example.spring.domain.member.MemberRole;
 import org.example.spring.domain.member.dto.MemberJoinRequestDto;
+import org.example.spring.domain.member.dto.MemberResponseDto;
 import org.example.spring.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +21,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,6 +97,24 @@ class MemberServiceTest {
         verify(memberRepository).existsByPhoneNumber(validMemberDto.getPhoneNumber());
         verify(memberRepository).save(any(Member.class));
 
+    }
+
+    @Test
+    @DisplayName("회원 전체 목록 조회 - 페이징")
+    void getAllMembers_no_search() {
+        // given
+        int page = 0;
+        int size = 10;
+        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
+        Page<Member> expectedPage = Page.empty();
+        given(memberRepository.findAll(pageable)).willReturn(expectedPage);
+
+        // when
+        Page<MemberResponseDto> result = memberService.getAllMembers(page, size);
+
+        // then
+        assertThat(result).isEqualTo(expectedPage);
+        then(memberRepository).should().findAll(pageable);
     }
 
 }


### PR DESCRIPTION
## 📝 PR 설명

회원 전체 목록을 조회하는 기능을 구현합니다. 페이지네이션을 지원하며, 회원의 주요 정보를 응답에 포함합니다.

## 🛠 변경 사항 
- ✨ `MemberController`에 `getAllMembers` 엔드포인트 추가
- ✨ `MemberService`에 `getAllMembers` 메서드 구현
- ✨ `MemberRepository`에 `findByNicknameContaining` 메서드 추가
- ✨ `MemberResponseDto` 클래스 생성
- ✅ `MemberController`와 `MemberService`에 대한 테스트 코드 작성
- 📚 각 클래스 및 메서드에 자바독 추가

## 🔍 테스트
- [x] 단위 테스트 추가/수정
  - `MemberController`의 `getAllMembers` 엔드포인트에 대한 테스트 케이스 작성
  - `MemberService`의 `getAllMembers` 메서드에 대한 테스트 케이스 작성
- [x] 통합 테스트 실행
  - 회원 등록 후 전체 목록 조회 테스트
  - 검색어를 포함하는 회원 목록 조회 테스트
  - 페이지네이션 동작 테스트
- [x] 수동 테스트 수행
  - Postman을 사용하여 API 동작 확인

## 🔗 관련 이슈
- Related To #49

## 📋 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트
- 현재는 회원 정보 중 일부만 응답에 포함되어 있는데, 추가로 필요한 정보가 있다면 의견 부탁드립니다.
