### PR TITLE
Refactor: FE REQUEST_URL 값을 BE 서버 주소로 연결

### DIFF
--- a/fe/play-baseball-fe/constants/endpoints.tsx
+++ b/fe/play-baseball-fe/constants/endpoints.tsx
@@ -1,4 +1,4 @@
-const REQUEST_URL: string = "http://localhost:8080/api";
+const REQUEST_URL: string = "3.36.114.27:8080/api";
 
 // Member Endpoints
 export const MEMBER: string = `${REQUEST_URL}/members`;


### PR DESCRIPTION
## 📝 PR 설명
연결 주소를 localhost:8080에서 AWS에 설치된 BE 서버로 연결합니다.

<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ♻️ endpoints.tsx의 REQUEST_URL 값을 AWS 주소로 변경

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->