### PR TITLE
Feat: SecurityConfig headers 옵션 추가

### DIFF
--- a/src/main/java/org/example/spring/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityConfig.java
@@ -18,6 +18,9 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.ContentTypeOptionsConfig;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.XXssConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -53,6 +56,12 @@ public class SecurityConfig {
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
         http.exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer.accessDeniedHandler(new CustomAccessDeniedHandler()));
+        http.headers(headersConfig -> headersConfig
+            .xssProtection(XXssConfig::disable)
+            .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'"))
+            .frameOptions(FrameOptionsConfig::sameOrigin)
+            .contentTypeOptions(withDefaults())
+        );
 
         return http.build();
     }


### PR DESCRIPTION
## 📝 PR 설명

<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ✨  xssProtection 비활성화
  - 최신 브라우저에서는 필요없음
  - 오래된 브라우저에서는 오히려 XSS 공경의 벡터가 될 수 있습니다.
- ✨ CSP 현재 웹페이지와 동일한 오리진에서만 리소스 로드 가능
- ✨ X-Frame-Options 현재 웹페이지와 동일한 오리진에서만 iframe으로 포함되도록 허용함
- ✨ contentTypeOptions 브라우저가 리소스의 Content-Type 헤더를 신뢰하도록 합니다.


## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [ ] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Closes #85 

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->