### PR TITLE
Refactor: SecurityConfig API 엔드포인트에 대한 보안 설정 개선 및 재구성

### DIFF
--- a/src/main/java/org/example/spring/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityConfig.java
@@ -13,13 +13,13 @@ import org.example.spring.security.jwt.JwtValidatorFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.ContentTypeOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.XXssConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -51,9 +51,29 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .addFilterBefore(jwtValidatorFilter(), UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(request -> request
-                .requestMatchers("/api/members", "api/members/verify-role/").hasAuthority(MemberRole.ADMIN.name())
-                .requestMatchers("/api/exchanges").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
-                .anyRequest().permitAll()
+                // 비회원 공개 엔드포인트
+                .requestMatchers(HttpMethod.POST, "/api/members/join", "/api/auth/login").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/members/verify/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/exchanges", "/api/exchanges/five").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/reviews").permitAll()
+
+                // 사용자 및 관리자 엔드포인트
+                .requestMatchers(HttpMethod.PUT, "/api/members/**").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.DELETE, "/api/members/my").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.GET, "/api/members/**").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.POST, "/api/exchanges", "/api/reviews").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.PUT, "/api/exchanges/**", "/api/reviews/**").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+
+                // 관리자 전용 엔드포인트
+                .requestMatchers(HttpMethod.GET, "/api/members").hasAuthority(MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.PUT, "/api/members/verify-role/**").hasAuthority(MemberRole.ADMIN.name())
+
+                // 인증된 사용자 엔드포인트
+                .requestMatchers(HttpMethod.GET, "/api/auth/logout", "/api/auth/reissue-token/**").authenticated()
+                .requestMatchers("/api/exchange-likes/**").authenticated()
+
+                // 기타 모든 요청
+                .anyRequest().authenticated()
             );
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));

--- a/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
@@ -13,6 +13,7 @@ import org.example.spring.security.jwt.JwtValidatorFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -49,9 +50,29 @@ public class SecurityDevConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .addFilterBefore(jwtValidatorFilter(), UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(request -> request
-                .requestMatchers("/api/members", "api/members/verify-role/").hasAuthority(MemberRole.ADMIN.name())
-                .requestMatchers("/api/exchanges").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
-                .anyRequest().permitAll()
+                // 비회원 공개 엔드포인트
+                .requestMatchers(HttpMethod.POST, "/api/members/join", "/api/auth/login").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/members/verify/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/exchanges", "/api/exchanges/five").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/reviews").permitAll()
+
+                // 사용자 및 관리자 엔드포인트
+                .requestMatchers(HttpMethod.PUT, "/api/members/**").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.DELETE, "/api/members/my").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.GET, "/api/members/**").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.POST, "/api/exchanges", "/api/reviews").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.PUT, "/api/exchanges/**", "/api/reviews/**").hasAnyAuthority(MemberRole.USER.name(), MemberRole.ADMIN.name())
+
+                // 관리자 전용 엔드포인트
+                .requestMatchers(HttpMethod.GET, "/api/members").hasAuthority(MemberRole.ADMIN.name())
+                .requestMatchers(HttpMethod.PUT, "/api/members/verify-role/**").hasAuthority(MemberRole.ADMIN.name())
+
+                // 인증된 사용자 엔드포인트
+                .requestMatchers(HttpMethod.GET, "/api/auth/logout", "/api/auth/reissue-token/**").authenticated()
+                .requestMatchers("/api/exchange-likes/**").authenticated()
+
+                // 기타 모든 요청
+                .anyRequest().authenticated()
             );
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));

--- a/src/test/java/org/example/spring/controller/ReviewControllerTest.java
+++ b/src/test/java/org/example/spring/controller/ReviewControllerTest.java
@@ -33,7 +33,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest

--- a/src/test/java/org/example/spring/controller/ReviewControllerTest.java
+++ b/src/test/java/org/example/spring/controller/ReviewControllerTest.java
@@ -33,10 +33,11 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 class ReviewControllerTest {
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## 📝 PR 설명

SecurityConfig API 엔드포인트에 대한 보안 설정 개선 및 재구성

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ♻️ 거래 목록 및 리뷰 조회 등 일부 엔드포인트에 대한 비회원 접근 허용
- ♻️ 권한 수준별 엔드포인트 그룹화로 가독성 향상
- ♻️ 회원, 인증, 거래, 리뷰 엔드포인트에 대한 세밀한 접근 제어 구현
- ♻️ USER와 ADMIN 역할 기반 접근 제어(RBAC) 적용
- ♻️ 인증이 필요한 엔드포인트와 공개 엔드포인트 명확히 구분

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [ ] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Closes #98 

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->