### PR TITLE
#110 Refactor: FE docker image 실행 시 포트번호 80 -> 8080으로 변경

### DIFF
--- a/.github/workflows/FE CD.yml
+++ b/.github/workflows/FE CD.yml
@@ -42,5 +42,5 @@ jobs:
             docker load < image.tar
             docker stop fe-container || true
             docker rm fe-container || true
-            docker run -d --name fe-container -p 80:3000 -e NODE_ENV=production play-baseball-fe:latest
+            docker run -d --name fe-container -p 8080:3000 -e NODE_ENV=production play-baseball-fe:latest
           '


### PR DESCRIPTION
## 📝 PR 설명
caddy https 통신을 위해 기존에 사용했던 Docker image 실행에 사용되던 80 포트번호를 변경합니다.
<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ♻️ FE CD.yml 파일 실행 명령어 수정

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #110 
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->