### PR TITLE
Feat: Rate Limiting 구현 및 SecurityFilterChain에 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Bucket4j
+    implementation group: 'com.bucket4j', name: 'bucket4j-core', version: '8.7.0'
+
     // JWT Dependencies
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/org/example/spring/constants/RateLimitBucketConstants.java
+++ b/src/main/java/org/example/spring/constants/RateLimitBucketConstants.java
@@ -1,0 +1,22 @@
+package org.example.spring.constants;
+
+import java.time.Duration;
+import lombok.Getter;
+
+@Getter
+public enum RateLimitBucketConstants {
+    AUTHENTICATED_CAPACITY(100),
+    UNAUTHENTICATED_CAPACITY(30),
+    REFILL_PERIOD_IN_MINUTES(1),
+    TOKEN_CONSUME_AMOUNT(1);
+
+    private final long value;
+
+    RateLimitBucketConstants(long value) {
+        this.value = value;
+    }
+
+    public Duration getDuration() {
+        return Duration.ofMinutes(value);
+    }
+}

--- a/src/main/java/org/example/spring/controller/AuthController.java
+++ b/src/main/java/org/example/spring/controller/AuthController.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.member.dto.LoginRequestDto;
 import org.example.spring.domain.member.dto.LoginResponseDto;
-import org.example.spring.service.AuthService;
+import org.example.spring.security.service.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/org/example/spring/security/filter/RateLimitFilter.java
+++ b/src/main/java/org/example/spring/security/filter/RateLimitFilter.java
@@ -1,0 +1,61 @@
+package org.example.spring.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.example.spring.security.jwt.JwtUtils;
+import org.example.spring.security.service.RateLimiterService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimiterService rateLimiter;
+    private final JwtUtils jwtUtils;
+
+    public RateLimitFilter(RateLimiterService rateLimiter, JwtUtils jwtUtils) {
+        this.rateLimiter = rateLimiter;
+        this.jwtUtils = jwtUtils;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        String token = jwtUtils.extractTokenFromHeader(request);
+        String clientIp = getClientIp(request);
+        String userAgent = request.getHeader("User-Agent");
+
+        log.info("Received request - hasToken: {}, IP: {}, User-Agent: {}", !token.isEmpty(), clientIp, userAgent);
+
+        if (rateLimiter.tryConsume(token, clientIp, userAgent)) {
+            log.info("Rate limit passed - hasToken: {}, IP: {}, User-Agent: {}", !token.isEmpty(), clientIp, userAgent);
+            filterChain.doFilter(request, response);
+        } else {
+            log.warn("Rate limit exceeded - hasToken: {}, IP: {}, User-Agent: {}", !token.isEmpty(), clientIp, userAgent);
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("status", HttpStatus.TOO_MANY_REQUESTS.value());
+            errorResponse.put("error", HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase());
+            errorResponse.put("message", "Too many requests. Please try again later.");
+            errorResponse.put("path", request.getRequestURI());
+
+            response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+        }
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/org/example/spring/security/jwt/CookieService.java
+++ b/src/main/java/org/example/spring/security/jwt/CookieService.java
@@ -48,7 +48,7 @@ public class CookieService {
     public void addRefreshTokenCookie(HttpServletResponse response, String token) {
         ResponseCookie cookie = ResponseCookie.from("refresh_token", token)
             .httpOnly(true)
-            .secure(false)
+            .secure(true)
             .path("/")
             .maxAge(jwtTokenProvider.getRefreshTokenExpiration())
             .sameSite("Lax")

--- a/src/main/java/org/example/spring/security/jwt/JwtTokenValidator.java
+++ b/src/main/java/org/example/spring/security/jwt/JwtTokenValidator.java
@@ -51,4 +51,13 @@ public class JwtTokenValidator {
         return validateToken(token).getExpiration().before(new Date());
     }
 
+    public boolean isTokenValid(String token) {
+        try {
+            validateToken(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
 }

--- a/src/main/java/org/example/spring/security/jwt/JwtTokenValidator.java
+++ b/src/main/java/org/example/spring/security/jwt/JwtTokenValidator.java
@@ -45,19 +45,11 @@ public class JwtTokenValidator {
      * JWT 토큰의 만료 여부를 확인합니다.
      *
      * @param token 확인할 JWT 토큰
-     * @return 토큰이 만료되었으면 true, 그렇지 않으면 false
+     * @return 토큰이 유효하면 true, 그렇지 않으면 false
      */
-    public boolean isTokenExpired(String token) {
-        return validateToken(token).getExpiration().before(new Date());
+    public boolean isTokenValid(String token) {
+        return !validateToken(token).getExpiration().before(new Date());
     }
 
-    public boolean isTokenValid(String token) {
-        try {
-            validateToken(token);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
 
 }

--- a/src/main/java/org/example/spring/security/jwt/JwtUtils.java
+++ b/src/main/java/org/example/spring/security/jwt/JwtUtils.java
@@ -1,11 +1,13 @@
 package org.example.spring.security.jwt;
 
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * JWT 관련 유틸리티 기능을 제공하는 클래스입니다.
@@ -41,6 +43,21 @@ public class JwtUtils {
      */
     public Key getSigningKey() {
         return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    /**
+     * 요청 헤더에서 토큰을 추출합니다.
+     *
+     * @param request HTTP 요청
+     * @return 추출된 토큰, 없으면 null
+     */
+    public String extractTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 
 }

--- a/src/main/java/org/example/spring/security/service/AuthService.java
+++ b/src/main/java/org/example/spring/security/service/AuthService.java
@@ -1,4 +1,4 @@
-package org.example.spring.service;
+package org.example.spring.security.service;
 
 import jakarta.servlet.http.HttpServletResponse;
 import org.example.spring.domain.member.dto.LoginRequestDto;

--- a/src/main/java/org/example/spring/security/service/JwtAuthenticationService.java
+++ b/src/main/java/org/example/spring/security/service/JwtAuthenticationService.java
@@ -34,9 +34,9 @@ public class JwtAuthenticationService {
      * @throws RuntimeException 두 토큰 모두 유효하지 않거나 만료된 경우
      */
     public void authenticateWithTokens(String accessToken, String refreshToken, HttpServletResponse response) {
-        if (accessToken != null && !jwtTokenValidator.isTokenExpired(accessToken)) {
+        if (accessToken != null && jwtTokenValidator.isTokenValid(accessToken)) {
             processToken(accessToken);
-        } else if (refreshToken != null && !jwtTokenValidator.isTokenExpired(refreshToken)) {
+        } else if (refreshToken != null && jwtTokenValidator.isTokenValid(refreshToken)) {
             Authentication authentication = createAuthenticationFromToken(refreshToken);
             String newAccessToken = jwtTokenProvider.generateAccessToken(authentication);
 

--- a/src/main/java/org/example/spring/security/service/RateLimiterService.java
+++ b/src/main/java/org/example/spring/security/service/RateLimiterService.java
@@ -24,7 +24,7 @@ public class RateLimiterService {
     }
 
     public boolean tryConsume(String token, String ip, String userAgent) {
-        if (token != null && !jwtTokenValidator.isTokenExpired(token) && jwtTokenValidator.isTokenValid(token)) {
+        if (token != null && jwtTokenValidator.isTokenValid(token)) {
             // 인증된 사용자
             String email = jwtTokenValidator.extractUsername(token);
             log.info("Authenticated user - Email: {}", email);

--- a/src/main/java/org/example/spring/security/service/RateLimiterService.java
+++ b/src/main/java/org/example/spring/security/service/RateLimiterService.java
@@ -1,0 +1,82 @@
+package org.example.spring.security.service;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BandwidthBuilder;
+import io.github.bucket4j.Bucket;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.example.spring.constants.RateLimitBucketConstants;
+import org.example.spring.security.jwt.JwtTokenValidator;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class RateLimiterService {
+
+    private final Map<String, Bucket> unauthenticatedBuckets = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> authenticatedBuckets = new ConcurrentHashMap<>();
+    private final JwtTokenValidator jwtTokenValidator;
+
+    public RateLimiterService(JwtTokenValidator jwtTokenValidator) {
+        this.jwtTokenValidator = jwtTokenValidator;
+    }
+
+    public boolean tryConsume(String token, String ip, String userAgent) {
+        if (token != null && !jwtTokenValidator.isTokenExpired(token) && jwtTokenValidator.isTokenValid(token)) {
+            // 인증된 사용자
+            String email = jwtTokenValidator.extractUsername(token);
+            log.info("Authenticated user - Email: {}", email);
+            return tryConsumeAuthenticated(email);
+        } else {
+            // 인증되지 않은 사용자
+            log.info("Unauthenticated user - IP: {}, User-Agent: {}", ip, userAgent);
+            return tryConsumeUnauthenticated(ip, userAgent);
+        }
+    }
+
+    private boolean tryConsumeAuthenticated(String email) {
+        Bucket bucket = authenticatedBuckets.computeIfAbsent(email, this::createAuthenticatedBucket);
+        boolean consumed = bucket.tryConsume(RateLimitBucketConstants.TOKEN_CONSUME_AMOUNT.getValue());
+        log.info("Authenticated user - Email: {}, Consumed: {}", email, consumed);
+        return consumed;
+    }
+
+    private boolean tryConsumeUnauthenticated(String ip, String userAgent) {
+        String key = ip + "|" + userAgent;
+        Bucket bucket = unauthenticatedBuckets.computeIfAbsent(key, this::createUnauthenticatedBucket);
+        boolean consumed = bucket.tryConsume(RateLimitBucketConstants.TOKEN_CONSUME_AMOUNT.getValue());
+        log.info("Unauthenticated user - IP: {}, User-Agent: {}, Consumed: {}", ip, userAgent, consumed);
+        return consumed;
+    }
+
+    private Bucket createAuthenticatedBucket(String email) {
+        long capacity = RateLimitBucketConstants.AUTHENTICATED_CAPACITY.getValue();
+        Duration period = RateLimitBucketConstants.REFILL_PERIOD_IN_MINUTES.getDuration();
+
+        Bandwidth limit = BandwidthBuilder.builder()
+            .capacity(capacity)
+            .refillGreedy(capacity, period)
+            .build();
+
+        return Bucket.builder()
+            .addLimit(limit)
+            .build();
+    }
+
+    private Bucket createUnauthenticatedBucket(String key) {
+        long capacity = RateLimitBucketConstants.UNAUTHENTICATED_CAPACITY.getValue();
+        Duration period = RateLimitBucketConstants.REFILL_PERIOD_IN_MINUTES.getDuration();
+
+        Bandwidth limit = BandwidthBuilder.builder()
+            .capacity(capacity)
+            .refillGreedy(capacity, period)
+            .build();
+
+        return Bucket.builder()
+            .addLimit(limit)
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 📝 PR 설명

이 PR은 JWT 토큰 검증 및 요청 속도 제한 기능을 추가합니다. 주로 JWT 토큰의 유효성을 검사하고, 클라이언트의 요청 속도를 제한하는 필터를 구현했습니다. 또한, 코드의 가독성을 높이기 위해 상수를 사용하여 매직 넘버를 제거했습니다.

## 🛠 변경 사항

- ✨ **새 기능**:
  - ✨ `RateLimiterService` 클래스 추가: 인증된 사용자와 인증되지 않은 사용자에 대한 속도 제한 기능을 구현했습니다.
  - ✨ `RateLimitFilter` 클래스 추가: 요청의 JWT 토큰을 검증하고, 요청 속도를 제한합니다.
  
- ♻️ **리팩토링**:
  - `RateLimitBucketConstants` enum 추가: 속도 제한 관련 상수를 관리하기 위해 enum을 사용했습니다.
  - `isTokenExpired`와 `isTokenValid` 메서드의 논리와 주석을 개선하여 코드의 명확성을 높였습니다.

## 🔍 테스트

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행
  - 수동으로 필터와 서비스가 예상대로 동작하는지 확인했습니다.

## 📸 스크린샷 (선택사항)

![image](https://github.com/user-attachments/assets/72ab3227-09b6-448f-9277-86d05c6ee61e)

## 🔗 관련 이슈

- Closes #109 

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

