### PR TITLE
Fix: Spring 서버 http -> https 무한 리디렉션 문제 해결

### DIFF
--- a/src/main/java/org/example/spring/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityConfig.java
@@ -87,6 +87,11 @@ public class SecurityConfig {
             .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'"))
             .frameOptions(FrameOptionsConfig::sameOrigin)
             .contentTypeOptions(withDefaults())
+            .httpStrictTransportSecurity(hsts -> hsts
+                    .includeSubDomains(true)
+                    .preload(true)
+                    .maxAgeInSeconds(31536000)
+            )
         );
 
         return http.build();

--- a/src/main/java/org/example/spring/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityConfig.java
@@ -76,6 +76,12 @@ public class SecurityConfig {
                 // 기타 모든 요청
                 .anyRequest().authenticated()
             );
+
+        // Https 요청 확인
+        http.requiresChannel(channel -> channel
+                .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null).requiresSecure()
+        );
+
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
         http.exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer.accessDeniedHandler(new CustomAccessDeniedHandler()));

--- a/src/main/java/org/example/spring/security/config/SecurityConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityConfig.java
@@ -48,7 +48,9 @@ public class SecurityConfig {
             .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .cors(corsConfig -> corsConfig.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
-            .requiresChannel(rcc -> rcc.anyRequest().requiresSecure())
+            .requiresChannel(channel -> channel
+                    .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null).requiresSecure()
+            )
             .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtValidatorFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(request -> request
@@ -76,11 +78,6 @@ public class SecurityConfig {
                 // 기타 모든 요청
                 .anyRequest().authenticated()
             );
-
-        // Https 요청 확인
-        http.requiresChannel(channel -> channel
-                .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null).requiresSecure()
-        );
 
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));

--- a/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
@@ -75,6 +75,12 @@ public class SecurityDevConfig {
                 // 기타 모든 요청
                 .anyRequest().authenticated()
             );
+
+        // Https 요청 확인
+        http.requiresChannel(channel -> channel
+                .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null).requiresSecure()
+        );
+
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
         http.exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer.accessDeniedHandler(new CustomAccessDeniedHandler()));

--- a/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -81,6 +82,17 @@ public class SecurityDevConfig {
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
         http.exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer.accessDeniedHandler(new CustomAccessDeniedHandler()));
+        http.headers(headersConfig -> headersConfig
+                .xssProtection(HeadersConfigurer.XXssConfig::disable)
+                .contentSecurityPolicy(csp -> csp.policyDirectives("default-src 'self'"))
+                .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+                .contentTypeOptions(withDefaults())
+                .httpStrictTransportSecurity(hsts -> hsts
+                        .includeSubDomains(true)
+                        .preload(true)
+                        .maxAgeInSeconds(31536000)
+                )
+        );
 
         return http.build();
     }

--- a/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
+++ b/src/main/java/org/example/spring/security/config/SecurityDevConfig.java
@@ -47,7 +47,9 @@ public class SecurityDevConfig {
             .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .cors(corsConfig -> corsConfig.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
-            .requiresChannel(rcc -> rcc.anyRequest().requiresInsecure())
+            .requiresChannel(channel -> channel
+                    .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null).requiresSecure()
+            )
             .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtValidatorFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(request -> request
@@ -75,11 +77,6 @@ public class SecurityDevConfig {
                 // 기타 모든 요청
                 .anyRequest().authenticated()
             );
-
-        // Https 요청 확인
-        http.requiresChannel(channel -> channel
-                .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null).requiresSecure()
-        );
 
         http.formLogin(withDefaults());
         http.httpBasic(basicConfig -> basicConfig.authenticationEntryPoint(new CustomAuthenticationEntryPoint()));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+
+
 spring:
   application:
     name: Play_Baseball
@@ -52,3 +54,5 @@ jwt:
   refresh-token:
     expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}  # 7일
 
+server:
+  forward-headers-strategy: framework


### PR DESCRIPTION
## 📝 PR 설명
Caddy proxy 서버 뒤에 Spring Boot BE 서버가 실행이 되는데 현재 충돌되는 부분이 존재합니다.
- https 요청을 보내도 Spring에서는 http로 처리하려는 특성으로 인해 http로 리다이렉트 시킴
- Caddy는 http요청이 들어오면 https로 변환 후 리다이렉트 시킴

따라서 https요청이 Spring으로 들어왔을 때 특정 헤더를 감지하여 http로 리디렉션 하지 않도록 

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- 🐛 SecurityConfig에서 X-Forwarded-Proto 헤더를 검사 후 https로 처리할 수 있도록 코드 추가
- 🐛 위와 동일한 내용 dev profile에도 추가

## 🔍 테스트
적용 및 배포 후 요청이 처리되는지 검사할 예정입니다.

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #116 
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트
### 보안 관련
위 변경사항으로 인해 Header Spoofing이 우려될 수 있으니 추후 BE 서버로 요청할 때는 FE 서버의 ip만 받도록 보안 설정이 필요할 수 있습니다.

### 인증서 관련
Caddy를 통해 SSL 인증서를 발급받아도 domain을 구매하지 않는다면 외부에서 신뢰성 있는 인증서로 인식하지 않아 https 접속이 불가능합니다.
일단 개인적으로 보유중인 도메인을 임시로 적용한 상태이며 도메인은 추후 변경이 가능합니다.
- FE서버 주소: ioshane.com
- BE서버 주소: api.ioshane.com
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->