### PR TITLE
Feat: 회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/org/example/spring/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/spring/common/GlobalExceptionHandler.java
@@ -64,7 +64,7 @@ public class GlobalExceptionHandler {
         if (ex.getCause() instanceof InvalidFormatException cause) {
             if (cause.getTargetType() != null && cause.getTargetType().isEnum()) {
                 errorMessage = String.format("'%s' 필드에 잘못된 값이 전달되었습니다. '%s' 중 하나의 값을 선택해주세요.",
-                    cause.getPath().get(0).getFieldName(),
+                    cause.getPath().getFirst().getFieldName(),
                     Arrays.asList(cause.getTargetType().getEnumConstants()));
             }
         }

--- a/src/main/java/org/example/spring/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/spring/common/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package org.example.spring.common;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.example.spring.exception.AccountBannedException;
 import org.example.spring.exception.AccountDeletedException;
@@ -7,6 +9,7 @@ import org.example.spring.exception.InvalidCredentialsException;
 import org.example.spring.exception.InvalidTokenException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -53,5 +56,19 @@ public class GlobalExceptionHandler {
         log.warn("Invalid token: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(ApiResponseDto.error("토큰이 유효하지 않습니다 " + ex.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        String errorMessage = "잘못된 요청 데이터가 전달되었습니다.";
+        if (ex.getCause() instanceof InvalidFormatException cause) {
+            if (cause.getTargetType() != null && cause.getTargetType().isEnum()) {
+                errorMessage = String.format("'%s' 필드에 잘못된 값이 전달되었습니다. '%s' 중 하나의 값을 선택해주세요.",
+                    cause.getPath().get(0).getFieldName(),
+                    Arrays.asList(cause.getTargetType().getEnumConstants()));
+            }
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponseDto.error(errorMessage));
     }
 }

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.member.dto.MemberJoinRequestDto;
+import org.example.spring.domain.member.dto.MemberModifyRequestDto;
 import org.example.spring.domain.member.dto.MemberResponseDto;
 import org.example.spring.service.MemberService;
 import org.springframework.data.domain.Page;
@@ -78,5 +79,17 @@ public class MemberController {
     public ResponseEntity<ApiResponseDto<Void>> deleteMember(HttpServletRequest request, HttpServletResponse response) {
         memberService.deleteMember(request, response);
         return ResponseEntity.ok(ApiResponseDto.success("회원 삭제 성공", null));
+    }
+
+    /**
+     * 요청온 Request 에서 추출한 email 을 가지고 있는 회원을 modify 합니다.
+     *
+     * @param request 요청
+     * @return 수정된 회원 응답 Dto
+     */
+    @PutMapping("/my/modify-member")
+    public ResponseEntity<ApiResponseDto<MemberResponseDto>> modifyMember(HttpServletRequest request, @RequestBody MemberModifyRequestDto member) {
+        MemberResponseDto modifiedMember = memberService.modifyMember(request, member);
+        return ResponseEntity.ok(ApiResponseDto.success("회원 정보 수정 성공:", modifiedMember));
     }
 }

--- a/src/main/java/org/example/spring/domain/member/Member.java
+++ b/src/main/java/org/example/spring/domain/member/Member.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.spring.constants.Gender;
+import org.example.spring.domain.member.dto.MemberModifyRequestDto;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -76,9 +77,20 @@ public class Member {
     @Column(name = "role", nullable = false, columnDefinition = "ENUM('USER', 'ADMIN', 'BANNED') DEFAULT 'USER'")
     private MemberRole role;
 
+    public void updateFrom(MemberModifyRequestDto dto) {
+        this.email = dto.getEmail();
+        this.password = dto.getPassword();
+        this.nickname = dto.getNickname();
+        this.name = dto.getName();
+        this.phoneNumber = dto.getPhoneNumber();
+        this.gender = dto.getGender();
+        this.updatedAt = Timestamp.from(Instant.now());
+    }
+
     public void updateLastLoginDate() {
         this.lastLoginDate = Timestamp.from(Instant.now());
     }
+
     public void updateDeletedAt() {
         this.deletedAt = Timestamp.from(Instant.now());
     }

--- a/src/main/java/org/example/spring/domain/member/dto/MemberModifyRequestDto.java
+++ b/src/main/java/org/example/spring/domain/member/dto/MemberModifyRequestDto.java
@@ -1,0 +1,51 @@
+package org.example.spring.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.example.spring.constants.Gender;
+import org.example.spring.domain.member.Member;
+
+/**
+ * DTO for {@link Member}
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class MemberModifyRequestDto {
+
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "유효한 이메일 주소를 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+        message = "비밀번호는 8자 이상이며, 문자, 숫자, 특수문자를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+    @Size(min = 2, max = 20, message = "닉네임은 2자에서 20자 사이여야 합니다.")
+    private String nickname;
+
+    @NotBlank(message = "이름은 필수 입력 항목입니다.")
+    private String name;
+
+    @NotBlank(message = "전화번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다. (예: 010-1234-5678)")
+    private String phoneNumber;
+
+    @NotNull(message = "성별은 필수 선택 항목입니다.")
+    private Gender gender;
+
+}

--- a/src/main/java/org/example/spring/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/org/example/spring/domain/member/dto/MemberResponseDto.java
@@ -25,7 +25,9 @@ public class MemberResponseDto {
     private String nickname;
     private MemberRole role;
     private Timestamp createdAt;
+    private Timestamp updatedAt;
     private Timestamp lastLoginDate;
+    private Timestamp deletedAt;
 
     public static MemberResponseDto toDto(Member member) {
         return MemberResponseDto.builder()
@@ -34,7 +36,9 @@ public class MemberResponseDto {
             .nickname(member.getNickname())
             .role(member.getRole())
             .createdAt(member.getCreatedAt())
+            .updatedAt(member.getUpdatedAt())
             .lastLoginDate(member.getLastLoginDate())
+            .deletedAt(member.getDeletedAt())
             .build();
     }
 }

--- a/src/main/java/org/example/spring/security/filter/JwtValidatorFilter.java
+++ b/src/main/java/org/example/spring/security/filter/JwtValidatorFilter.java
@@ -75,7 +75,7 @@ public class JwtValidatorFilter extends OncePerRequestFilter {
             boolean tokenRefreshed = false;
             Authentication authentication;
             try {
-                authentication = jwtAuthenticationService.authenticateWithTokens(accessToken, refreshToken, request, response);
+                authentication = jwtAuthenticationService.authenticateWithTokens(accessToken, refreshToken, request);
                 log.debug("Authentication successful without token refresh");
             } catch (ExpiredJwtException e) {
                 log.debug("ExpiredJwtException caught, attempting to refresh token");

--- a/src/main/java/org/example/spring/security/service/JwtAuthenticationService.java
+++ b/src/main/java/org/example/spring/security/service/JwtAuthenticationService.java
@@ -35,10 +35,9 @@ public class JwtAuthenticationService {
      *
      * @param accessToken 액세스 토큰
      * @param refreshToken 리프레시 토큰
-     * @param response HTTP 응답
      * @throws RuntimeException 두 토큰 모두 유효하지 않거나 만료된 경우
      */
-    public Authentication authenticateWithTokens(String accessToken, String refreshToken, HttpServletRequest request, HttpServletResponse response) {
+    public Authentication authenticateWithTokens(String accessToken, String refreshToken, HttpServletRequest request) {
         try {
             if (accessToken != null && refreshToken != null &&
                 jwtTokenValidator.validateAccessAndRefreshTokenConsistency(accessToken, refreshToken)) {


### PR DESCRIPTION
## 📝 PR 설명
회원 정보 수정 API의 기능을 구현하고 관련 예외 처리를 추가했습니다

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ✨ MemberController에 modifyMember 메서드 추가
- ✨ MemberService에 modifyMember 메서드 추가
- ✨ Member 엔티티에 updateFrom 메서드 추가
- ✨ MemberModifyRequestDto 클래스 생성
- 🐛 GlobalExceptionHandler에 HttpMessageNotReadableException 처리 로직 추가
- 🐛 MemberResponseDto 필드 추가

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

![image](https://github.com/user-attachments/assets/5a80823d-9117-4223-a7ab-cfc4713141c9)

## 🔗 관련 이슈
Relates to #128 

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->