### PR TITLE
Feat: 회권 권한 수정 기능 구현

### DIFF
--- a/src/main/java/org/example/spring/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/spring/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.example.spring.common;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.example.spring.exception.AccountBannedException;
@@ -10,6 +11,7 @@ import org.example.spring.exception.InvalidTokenException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -69,6 +71,14 @@ public class GlobalExceptionHandler {
             }
         }
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponseDto.error(errorMessage));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleAccessDeniedException(AccessDeniedException ex, HttpServletRequest request) {
+        log.warn("access denied: {}", ex.getMessage());
+        String errorMessage = "'" + request.getRequestURI() + "' 경로에 대한 접근 권한이 없습니다.";
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
             .body(ApiResponseDto.error(errorMessage));
     }
 }

--- a/src/main/java/org/example/spring/controller/MemberController.java
+++ b/src/main/java/org/example/spring/controller/MemberController.java
@@ -7,11 +7,14 @@ import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.member.dto.MemberJoinRequestDto;
 import org.example.spring.domain.member.dto.MemberModifyRequestDto;
 import org.example.spring.domain.member.dto.MemberResponseDto;
+import org.example.spring.domain.member.dto.MemberRoleModifyRequestDto;
 import org.example.spring.service.MemberService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -91,5 +94,21 @@ public class MemberController {
     public ResponseEntity<ApiResponseDto<MemberResponseDto>> modifyMember(HttpServletRequest request, @RequestBody MemberModifyRequestDto member) {
         MemberResponseDto modifiedMember = memberService.modifyMember(request, member);
         return ResponseEntity.ok(ApiResponseDto.success("회원 정보 수정 성공:", modifiedMember));
+    }
+
+    /**
+     * admin 권한을 가지고 있으면 회원의 권한을 수정할 수 있습니다.
+     * @param memberId 수정할 회원 ID
+     * @param memberRoleModifyRequestDto 변경할 권한 요청
+     * @param request HttpServletRequest
+     * @return 권한이 변경된 회원 Dto
+     */
+    @PatchMapping("verify-role/{memberId}")
+    public ResponseEntity<ApiResponseDto<MemberResponseDto>> modifyMemberRole(
+        @PathVariable Long memberId,
+        @RequestBody MemberRoleModifyRequestDto memberRoleModifyRequestDto,
+        HttpServletRequest request) {
+        MemberResponseDto modifiedMember = memberService.modifyMemberRole(memberId, memberRoleModifyRequestDto, request);
+        return ResponseEntity.ok(ApiResponseDto.success("회원 권한 수정 성공", modifiedMember));
     }
 }

--- a/src/main/java/org/example/spring/domain/member/Member.java
+++ b/src/main/java/org/example/spring/domain/member/Member.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 import java.time.Instant;
 import lombok.AccessLevel;
@@ -93,5 +94,9 @@ public class Member {
 
     public void updateDeletedAt() {
         this.deletedAt = Timestamp.from(Instant.now());
+    }
+
+    public void updateRole(@NotNull(message = "권한 정보는 필수입니다.") MemberRole role) {
+        this.role = role;
     }
 }

--- a/src/main/java/org/example/spring/domain/member/dto/MemberRoleModifyRequestDto.java
+++ b/src/main/java/org/example/spring/domain/member/dto/MemberRoleModifyRequestDto.java
@@ -1,0 +1,25 @@
+package org.example.spring.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.example.spring.domain.member.Member;
+import org.example.spring.domain.member.MemberRole;
+
+/**
+ * DTO for {@link Member}
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class MemberRoleModifyRequestDto {
+
+    @NotNull(message = "권한 정보는 필수입니다.")
+    private MemberRole role;
+}


### PR DESCRIPTION
## 📝 PR 설명

관리자가 회원의 권한을 수정할 수 있는 기능을 구현 했습니다. 관리자는 특정 회원의 권한을 USER, ADMIN, BANNED 로 지정할 수 있습니다.

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ✨ MemberController에 modifyMemberRole 메서드 추가
- ✨ MemberService에 modifyMemberRole 메서드 추가
- ✨ MemberRoleModifyRequestDto 클래스 생성
- 🐛 GlobalExceptionHandler에 AccessDeniedException 처리 로직 추가

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

일반 회원 권한으로 요청했을떄
![image](https://github.com/user-attachments/assets/b379ceb5-f384-48c5-a54d-5f735cb248b3)

## 🔗 관련 이슈
Relates to #128 

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->