### PR TITLE
Feat: 회원정보 3일 후 폐기 기능 구현

### DIFF
--- a/.github/workflows/Spring CD.yml
+++ b/.github/workflows/Spring CD.yml
@@ -58,5 +58,5 @@ jobs:
               pkill java
               sleep 5
             fi
-            nohup java -jar /home/$EC2_USER/playBaseballServer.jar > app.log 2>&1 &"
+            nohup java -Dspring.profiles.active=prod -jar /home/$EC2_USER/playBaseballServer.jar > app.log 2>&1 &"
           rm -f private_key.pem

--- a/src/main/java/org/example/spring/Application.java
+++ b/src/main/java/org/example/spring/Application.java
@@ -3,9 +3,11 @@ package org.example.spring;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/example/spring/repository/MemberRepository.java
+++ b/src/main/java/org/example/spring/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package org.example.spring.repository;
 
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.Optional;
 import org.example.spring.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +20,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    List<Member> findByDeletedAtBeforeAndDeletedAtIsNotNull(Timestamp deletedAt);
 }

--- a/src/main/java/org/example/spring/security/service/EmailService.java
+++ b/src/main/java/org/example/spring/security/service/EmailService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
 import org.example.spring.security.utils.JwtUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,9 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
     private final JwtUtils jwtUtils;
+
+    @Value("${app.base-url}")
+    private String baseUrl;
 
     @Autowired
     public EmailService(JavaMailSender mailSender, JwtUtils jwtUtils) {
@@ -26,10 +30,9 @@ public class EmailService {
         message.setTo(email);
         message.setSubject("이메일 인증");
         message.setText("다음 링크를 클릭하여 이메일을 인증하세요: " +
-            "https://api.ioshane.com/api/members/verify-email?token=" + token);
+            baseUrl + "/api/members/verify-email?token=" + token);
         mailSender.send(message);
     }
-
 
     public String generateEmailVerificationToken(String email) {
         return Jwts.builder()

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -68,6 +68,9 @@ jwt:
   email-verification:
     expiration: ${JWT_EMAIL_VERIFICATION_EXPIRATION}
 
+app:
+  base-url: https://api.ioshane.com
+
 #server:
 #  forward-headers-strategy: native
 #  tomcat:


### PR DESCRIPTION
## 📝 PR 설명

이 PR은 회원 탈퇴 후 3일이 지난 회원 정보를 자동으로 삭제하는 기능을 구현합니다.
탈퇴한 회원의 개인정보를 보호하고 불필요한 데이터를 정리하기 위한 목적입니다.
## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ✨ 회원 정보 삭제 스케줄링 기능 추가
- ✨ MemberRepository에 삭제 대상 회원 조회 메서드 추가

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Closes #181 

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->