### PR TITLE
Feat: FE Main page, Detail Page 기능 추가, BE 관련 내용 수정 및 메서드 추가

### DIFF
--- a/fe/play-baseball-fe/package-lock.json
+++ b/fe/play-baseball-fe/package-lock.json
@@ -11,14 +11,15 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mui/icons-material": "^6.0.0",
-        "@mui/material": "^6.0.1",
         "@mui/material": "^6.0.0",
         "axios": "^1.7.7",
+        "lodash": "^4.17.21",
         "next": "14.2.6",
         "react": "^18",
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@types/lodash": "^4.17.7",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1094,6 +1095,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4077,6 +4085,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/fe/play-baseball-fe/package.json
+++ b/fe/play-baseball-fe/package.json
@@ -12,14 +12,15 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.0.0",
-    "@mui/material": "^6.0.1",
     "@mui/material": "^6.0.0",
     "axios": "^1.7.7",
+    "lodash": "^4.17.21",
     "next": "14.2.6",
     "react": "^18",
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.7",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/fe/play-baseball-fe/pages/exchange/[id].tsx
+++ b/fe/play-baseball-fe/pages/exchange/[id].tsx
@@ -6,42 +6,74 @@ import {
   Divider,
   Button,
   IconButton,
-  Card,
-  CardContent,
   Grid,
   Fade,
   Rating,
   Paper,
+  Modal,
 } from "@mui/material";
+import axios from "axios";
 import { ArrowBack, ArrowForward } from "@mui/icons-material";
 import Image from "next/image";
+import { useRouter } from "next/router";
+import { EXCHANGE } from "@/constants/endpoints";
 
-// Temporary data
-const itemImages = [
-  { img: "/exchange/image.jpg", title: "Image 1" },
-  { img: "/exchange/image2.jpg", title: "Image 2" },
-  { img: "/exchange/image3.jpg", title: "Image 3" },
-];
-
-const recommendedItems = [
-  { img: "/exchange/image.jpg", title: "Product 1", price: "10,000원" },
-  { img: "/exchange/image2.jpg", title: "Product 2", price: "15,000원" },
-  { img: "/exchange/image3.jpg", title: "Product 3", price: "20,000원" },
-  { img: "/exchange/image.jpg", title: "Product 4", price: "25,000원" },
-];
+// Mock data in the structure of ExchangeDetailResponseDto
+const mockData = {
+  title: "휴대폰",
+  price: 191000,
+  regularPrice: 1000000,
+  content: "이 상품은 거의 새 제품과 다름없습니다.",
+  viewCount: 123,
+  status: "SALE", // 판매중(SALE) 혹은 판매완료(COMPLETE)
+  updatedAt: "2024-08-29T12:34:56",
+  images: [
+    { url: "/exchange/image.jpg", title: "Image 1" },
+    { url: "/exchange/image2.jpg", title: "Image 2" },
+    { url: "/exchange/image3.jpg", title: "Image 3" },
+  ],
+  writer: "닉네임",
+  recentExchangesByMember: [
+    {
+      title: "최근 게시글 1",
+      price: 20000,
+      url: `/exchange/1`,
+      imageUrl: "/exchange/image.jpg",
+      updatedAt: "2024-08-29T12:34:56",
+    },
+    {
+      title: "최근 게시글 2",
+      price: 25000,
+      url: `/exchange/2`,
+      imageUrl: "/exchange/image2.jpg",
+      updatedAt: "2024-08-29T12:34:56",
+    },
+    {
+      title: "최근 게시글 3",
+      price: 30000,
+      url: `/exchange/3`,
+      imageUrl: "/exchange/image3.jpg",
+      updatedAt: "2024-08-29T12:34:56",
+    },
+  ],
+  isWriter: true, // 현재 사용자가 작성자인지 여부
+};
 
 const ItemDetail: React.FC = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [hover, setHover] = useState(false);
+  const [openModal, setOpenModal] = useState(false);
+  const router = useRouter();
 
   const handlePrev = () => {
     setCurrentIndex(
-      (prevIndex) => (prevIndex - 1 + itemImages.length) % itemImages.length
+      (prevIndex) =>
+        (prevIndex - 1 + mockData.images.length) % mockData.images.length
     );
   };
 
   const handleNext = () => {
-    setCurrentIndex((prevIndex) => (prevIndex + 1) % itemImages.length);
+    setCurrentIndex((prevIndex) => (prevIndex + 1) % mockData.images.length);
   };
 
   const handleMouseEnter = () => {
@@ -50,6 +82,41 @@ const ItemDetail: React.FC = () => {
 
   const handleMouseLeave = () => {
     setHover(false);
+  };
+
+  const handleDelete = async () => {
+    const token =
+      typeof window !== "undefined"
+        ? localStorage.getItem("Authorization")
+        : null;
+
+    try {
+      await axios.delete(`${EXCHANGE}/${router.query.id}`, {
+        headers: {
+          Authorization: token,
+        },
+        withCredentials: true,
+      });
+      router.push({
+        pathname: "/result",
+        query: {
+          isSuccess: "true",
+          message: `글이 정상적으로 삭제되었습니다. ${mockData.title}`,
+          buttonText: "메인으로 돌아가기",
+          buttonAction: `/`,
+        },
+      });
+    } catch (error) {
+      router.push({
+        pathname: "/result",
+        query: {
+          isSuccess: "false",
+          message: `통신 오류가 발생했습니다: ${error}`,
+          buttonText: "작성한 글로 돌아가기",
+          buttonAction: `/exchange/${router.query.id}`,
+        },
+      });
+    }
   };
 
   return (
@@ -91,8 +158,8 @@ const ItemDetail: React.FC = () => {
                 </IconButton>
               </Fade>
               <Image
-                src={itemImages[currentIndex].img}
-                alt={itemImages[currentIndex].title}
+                src={mockData.images[currentIndex].url}
+                alt={mockData.images[currentIndex].title}
                 layout="responsive"
                 width={700}
                 height={400}
@@ -116,7 +183,7 @@ const ItemDetail: React.FC = () => {
 
             {/* Indicators */}
             <Box display="flex" justifyContent="center" mt={1}>
-              {itemImages.map((_, index) => (
+              {mockData.images.map((_, index) => (
                 <Box
                   key={index}
                   onClick={() => setCurrentIndex(index)}
@@ -137,17 +204,18 @@ const ItemDetail: React.FC = () => {
         {/* Product Info */}
         <Grid item xs={12} md={6}>
           <Paper elevation={3} sx={{ padding: "20px" }}>
-            <Typography variant="h5">휴대폰</Typography>
-            <Typography variant="body1">휴대폰-삼성</Typography>
+            <Typography variant="h5">{mockData.title}</Typography>
             <Typography variant="h5" color="primary" sx={{ marginTop: "10px" }}>
-              191,000원
+              {mockData.price.toLocaleString()}원
             </Typography>
             <Divider sx={{ margin: "20px 0" }} />
-            <Typography variant="body1">주소</Typography>
-            <Typography variant="body1">상태</Typography>
+            <Typography variant="body1">
+              상태: {mockData.status === "SALE" ? "판매중" : "판매완료"}
+            </Typography>
             <Divider sx={{ margin: "20px 0" }} />
             <Typography variant="body1">
-              이 상품의 정가는 1,000,000원 입니다.
+              이 상품의 정가는 {mockData.regularPrice.toLocaleString()}원
+              입니다.
             </Typography>
             <Divider sx={{ margin: "20px 0" }} />
             <Button variant="contained" fullWidth>
@@ -156,6 +224,29 @@ const ItemDetail: React.FC = () => {
             <Button variant="contained" fullWidth sx={{ mt: 2 }}>
               결제하기
             </Button>
+            {mockData.isWriter && (
+              <>
+                <Button
+                  variant="outlined"
+                  fullWidth
+                  sx={{ mt: 2 }}
+                  onClick={() =>
+                    router.push(`/exchange/write/${router.query.id}`)
+                  }
+                >
+                  수정하기
+                </Button>
+                <Button
+                  variant="outlined"
+                  fullWidth
+                  sx={{ mt: 2 }}
+                  color="error"
+                  onClick={() => setOpenModal(true)}
+                >
+                  삭제하기
+                </Button>
+              </>
+            )}
           </Paper>
         </Grid>
 
@@ -164,36 +255,22 @@ const ItemDetail: React.FC = () => {
           <Paper elevation={3} sx={{ padding: "20px" }}>
             <Typography variant="h4">상품 정보</Typography>
             <Typography color="textSecondary" sx={{ marginTop: "10px" }}>
-              작성일: 2024년 8월 29일
+              작성일: {new Date(mockData.updatedAt).toLocaleDateString()}
             </Typography>
-            <Typography color="textSecondary">조회: 123 채팅: 1212</Typography>
+            <Typography color="textSecondary">
+              조회: {mockData.viewCount}
+            </Typography>
             <Divider sx={{ margin: "20px 0" }} />
-            <Typography variant="body1">
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-              휴대폰 팝니다 <br />
-            </Typography>
+            <Typography variant="body1">{mockData.content}</Typography>
           </Paper>
         </Grid>
 
         {/* Seller Info */}
         <Grid item xs={12} md={6}>
           <Paper elevation={3} sx={{ padding: "20px" }}>
-            <Typography variant="h6">판매자 정보</Typography>
+            <Typography variant="h6">{mockData.writer}</Typography>
             <Box display="flex" alignItems="center">
               <Box display="flex" alignItems="center">
-                <Typography variant="h6">닉네임</Typography>
                 <Rating value={4.6} precision={0.1} readOnly />
                 <Typography
                   variant="body2"
@@ -206,57 +283,84 @@ const ItemDetail: React.FC = () => {
             </Box>
             <Divider sx={{ margin: "20px 0" }} />
             <Grid container spacing={1} mt={2}>
-              {recommendedItems.slice(0, 3).map((item, index) => (
-                <Grid item xs={4} key={index}>
-                  <Image
-                    src={item.img}
-                    alt={item.title}
-                    layout="responsive"
-                    width={100}
-                    height={100}
-                    objectFit="cover"
-                    style={{ borderRadius: "4px" }}
-                  />
-                  <Typography variant="caption" display="block" align="center">
-                    {item.title}
-                  </Typography>
-                  <Typography variant="caption" display="block" align="center">
-                    {item.price}
-                  </Typography>
-                </Grid>
-              ))}
+              {mockData.recentExchangesByMember.length > 0 ? (
+                mockData.recentExchangesByMember.map((item, index) => (
+                  <Grid
+                    item
+                    xs={4}
+                    key={index}
+                    onClick={() => router.push(item.url)} // 클릭 시 해당 URL로 이동
+                    sx={{
+                      cursor: "pointer",
+                      "&:hover": {
+                        boxShadow: 2, // 마우스 오버 시 박스 그림자 효과
+                      },
+                    }}
+                  >
+                    <Image
+                      src={item.imageUrl}
+                      alt={item.title}
+                      layout="responsive"
+                      width={100}
+                      height={100}
+                      objectFit="cover"
+                      style={{ borderRadius: "4px" }}
+                    />
+                    <Typography
+                      variant="caption"
+                      display="block"
+                      align="center"
+                    >
+                      {item.title}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      display="block"
+                      align="center"
+                    >
+                      {item.price.toLocaleString()}원
+                    </Typography>
+                  </Grid>
+                ))
+              ) : (
+                <Typography variant="body2" color="textSecondary">
+                  판매중인 다른 게시물이 없습니다.
+                </Typography>
+              )}
             </Grid>
           </Paper>
         </Grid>
 
-        {/* Recommended Products */}
-        <Grid item xs={12} md={12}>
-          <Typography variant="h5" gutterBottom>
-            이런 상품은 어떠세요?
-          </Typography>
-          <Grid container spacing={2}>
-            {recommendedItems.map((item, index) => (
-              <Grid item xs={6} sm={4} key={index}>
-                <Card>
-                  <Image
-                    src={item.img}
-                    alt={item.title}
-                    layout="responsive"
-                    width={100}
-                    height={100}
-                    objectFit="cover"
-                  />
-                  <CardContent>
-                    <Typography variant="body1">{item.title}</Typography>
-                    <Typography variant="body2" color="primary">
-                      {item.price}
-                    </Typography>
-                  </CardContent>
-                </Card>
-              </Grid>
-            ))}
-          </Grid>
-        </Grid>
+        {/* Delete Confirmation Modal */}
+        <Modal open={openModal} onClose={() => setOpenModal(false)}>
+          <Box
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              width: 400,
+              bgcolor: "background.paper",
+              boxShadow: 24,
+              p: 4,
+              textAlign: "center",
+            }}
+          >
+            <Typography variant="h6" gutterBottom>
+              정말 삭제하시겠습니까?
+            </Typography>
+            <Button variant="contained" color="error" onClick={handleDelete}>
+              확인
+            </Button>
+            <Button
+              variant="outlined"
+              sx={{ ml: 2 }}
+              onClick={() => setOpenModal(false)}
+            >
+              취소
+            </Button>
+          </Box>
+        </Modal>
       </Grid>
     </Container>
   );

--- a/fe/play-baseball-fe/pages/exchange/write/[id].tsx
+++ b/fe/play-baseball-fe/pages/exchange/write/[id].tsx
@@ -1,0 +1,200 @@
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/router";
+import {
+  Box,
+  TextField,
+  Button,
+  Typography,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+import Image from "next/image";
+import axios from "axios";
+import { EXCHANGE } from "@/constants/endpoints";
+
+const EditPostForm = () => {
+  const [title, setTitle] = useState("");
+  const [price, setPrice] = useState("");
+  const [content, setContent] = useState("");
+  const [status, setStatus] = useState("");
+  const [images, setImages] = useState<(File | string)[]>([]);
+  const router = useRouter();
+  const { id } = router.query;
+
+  useEffect(() => {
+    if (id) {
+      const fetchPostData = async () => {
+        try {
+          const response = await axios.get(`/api/exchanges/${id}`);
+          const { title, price, content, status, images } = response.data.data;
+          setTitle(title);
+          setPrice(price);
+          setContent(content);
+          setStatus(status);
+          setImages(images);
+        } catch (error) {
+          console.error("Error fetching post data:", error);
+        }
+      };
+      fetchPostData();
+    }
+  }, [id]);
+
+  const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value);
+  };
+
+  const handlePriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPrice(event.target.value);
+  };
+
+  const handleContentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setContent(event.target.value);
+  };
+
+  const handleStatusChange = (event: SelectChangeEvent<string>) => {
+    setStatus(event.target.value as string);
+  };
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files) {
+      const newImages = Array.from(event.target.files);
+      setImages((prevImages) => [...prevImages, ...newImages]);
+    }
+  };
+
+  const handleImageDelete = (index: number) => {
+    setImages((prevImages) => prevImages.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async () => {
+    const formData = new FormData();
+    const token =
+      typeof window !== "undefined"
+        ? localStorage.getItem("Authorization")
+        : null;
+    const jsonData = {
+      title,
+      price,
+      content,
+      status,
+    };
+    formData.append(
+      "exchangeRequestDto",
+      new Blob([JSON.stringify(jsonData)], { type: "application/json" })
+    );
+
+    images.forEach((image) => {
+      // 파일과 기존 URL 이미지를 분리하여 처리
+      if (typeof image !== "string") {
+        formData.append("images", image);
+      }
+    });
+
+    try {
+      const response = await axios.put(`${EXCHANGE}/${id}`, formData, {
+        headers: {
+          Authorization: token,
+          "Content-Type": "multipart/form-data",
+        },
+        withCredentials: true,
+      });
+      router.push({
+        pathname: "/result",
+        query: {
+          isSuccess: "true",
+          message: `글이 정상적으로 수정되었습니다. ${title}`,
+          buttonText: "수정된 글 확인하기",
+          buttonAction: `/exchange/${id}`,
+        },
+      });
+    } catch (error) {
+      router.push({
+        pathname: "/result",
+        query: {
+          isSuccess: "false",
+          message: `수정 도중 오류가 발생했습니다: ${error}`,
+          buttonText: "다시 시도하기",
+          buttonAction: `/exchange/write/${id}`,
+        },
+      });
+    }
+  };
+
+  return (
+    <Box
+      component="form"
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        maxWidth: 600,
+        margin: "0 auto",
+      }}
+    >
+      <Typography variant="h5">상품 수정</Typography>
+      <TextField label="제목" value={title} onChange={handleTitleChange} />
+      <TextField label="가격" value={price} onChange={handlePriceChange} />
+      <TextField
+        label="설명"
+        multiline
+        rows={4}
+        value={content}
+        onChange={handleContentChange}
+      />
+
+      <Typography>상태</Typography>
+      <Select value={status} onChange={handleStatusChange}>
+        <MenuItem value="SALE">판매중</MenuItem>
+        <MenuItem value="COMPLETE">판매완료</MenuItem>
+      </Select>
+
+      <Box>
+        <Typography>이미지 ({images.length}/12)</Typography>
+        <Button variant="outlined" component="label">
+          이미지 등록
+          <input type="file" hidden multiple onChange={handleImageChange} />
+        </Button>
+        <Box sx={{ display: "flex", gap: 1, marginTop: 2 }}>
+          {images.map((image, index) => (
+            <Box
+              key={index}
+              sx={{ position: "relative", width: 100, height: 100 }}
+            >
+              {typeof image === "string" ? (
+                <Image
+                  src={image}
+                  alt={`기존 이미지 ${index + 1}`}
+                  layout="fill"
+                  objectFit="cover"
+                />
+              ) : (
+                <Image
+                  src={URL.createObjectURL(image)}
+                  alt={`새 이미지 ${index + 1}`}
+                  layout="fill"
+                  objectFit="cover"
+                />
+              )}
+              <Button
+                variant="contained"
+                color="secondary"
+                sx={{ position: "absolute", top: 0, right: 0 }}
+                onClick={() => handleImageDelete(index)}
+              >
+                X
+              </Button>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      <Button variant="contained" color="primary" onClick={handleSubmit}>
+        수정 완료
+      </Button>
+    </Box>
+  );
+};
+
+export default EditPostForm;

--- a/fe/play-baseball-fe/pages/exchange/write/index.tsx
+++ b/fe/play-baseball-fe/pages/exchange/write/index.tsx
@@ -1,41 +1,27 @@
 import React, { useState } from "react";
-import {
-  Box,
-  TextField,
-  Button,
-  Select,
-  MenuItem,
-  FormControl,
-  InputLabel,
-  Typography,
-} from "@mui/material";
+import { useRouter } from "next/router";
+import { Box, TextField, Button, Typography } from "@mui/material";
 import Image from "next/image";
-import { SelectChangeEvent } from "@mui/material/Select";
+import axios from "axios";
+import { EXCHANGE_ADD } from "@/constants/endpoints";
 
 const PostCreationForm = () => {
   const [title, setTitle] = useState("");
-  const [category, setCategory] = useState("");
   const [price, setPrice] = useState("");
-  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
   const [images, setImages] = useState<File[]>([]);
-  const [mainImageIndex, setMainImageIndex] = useState<number | null>(null);
+  const router = useRouter();
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
-  };
-
-  const handleCategoryChange = (event: SelectChangeEvent<string>) => {
-    setCategory(event.target.value);
   };
 
   const handlePriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setPrice(event.target.value);
   };
 
-  const handleDescriptionChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setDescription(event.target.value);
+  const handleContentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setContent(event.target.value);
   };
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,26 +31,58 @@ const PostCreationForm = () => {
     }
   };
 
-  const handleImageClick = (index: number) => {
-    setMainImageIndex(index);
-  };
-
   const handleImageDelete = (index: number) => {
     setImages((prevImages) => prevImages.filter((_, i) => i !== index));
-    if (mainImageIndex === index) {
-      setMainImageIndex(null);
-    }
   };
 
-  const handleSubmit = () => {
-    console.log({
+  const handleSubmit = async () => {
+    const formData = new FormData();
+    const token =
+      typeof window !== "undefined"
+        ? localStorage.getItem("Authorization")
+        : null;
+    const jsonData = {
       title,
-      category,
       price,
-      description,
-      images,
-      mainImageIndex,
+      content,
+    };
+    formData.append(
+      "exchangeRequestDto",
+      new Blob([JSON.stringify(jsonData)], { type: "application/json" })
+    );
+
+    images.forEach((image) => {
+      formData.append("images", image);
     });
+
+    try {
+      const response = await axios.post(EXCHANGE_ADD, formData, {
+        headers: {
+          Authorization: token,
+          "Content-Type": "multipart/form-data",
+        },
+        withCredentials: true,
+      });
+      router.push({
+        pathname: "/result",
+        query: {
+          isSuccess: "true",
+          message: `글이 정상적으로 작성되었습니다. ${title}`,
+          buttonText: "작성한 글 확인하기",
+          buttonAction: `/exchanges/${response.data.id}`,
+        },
+      });
+    } catch (error) {
+      router.push({
+        pathname: "/result",
+        query: {
+          isSuccess: "false",
+          message: `통신 오류가 발생했습니다: ${error}`,
+          buttonText: "다시 시도하기",
+          buttonAction: "/",
+        },
+      });
+    }
   };
 
   return (
@@ -80,26 +98,13 @@ const PostCreationForm = () => {
     >
       <Typography variant="h5">상품 등록</Typography>
       <TextField label="제목" value={title} onChange={handleTitleChange} />
-      <FormControl>
-        <InputLabel id="category-label">카테고리</InputLabel>
-        <Select
-          labelId="category-label"
-          value={category}
-          onChange={handleCategoryChange}
-        >
-          <MenuItem value="전자기기">전자기기</MenuItem>
-          <MenuItem value="가구">가구</MenuItem>
-          <MenuItem value="의류">의류</MenuItem>
-          {/* 필요한 카테고리 추가 */}
-        </Select>
-      </FormControl>
       <TextField label="가격" value={price} onChange={handlePriceChange} />
       <TextField
         label="설명"
         multiline
         rows={4}
-        value={description}
-        onChange={handleDescriptionChange}
+        value={content}
+        onChange={handleContentChange}
       />
 
       <Box>
@@ -119,24 +124,7 @@ const PostCreationForm = () => {
                 alt={`상품 이미지 ${index + 1}`}
                 layout="fill"
                 objectFit="cover"
-                onClick={() => handleImageClick(index)}
-                style={{
-                  border: mainImageIndex === index ? "2px solid blue" : "none",
-                }}
               />
-              {mainImageIndex === index && (
-                <Typography
-                  sx={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    backgroundColor: "white",
-                    padding: "2px 4px",
-                  }}
-                >
-                  대표이미지
-                </Typography>
-              )}
               <Button
                 variant="contained"
                 color="secondary"

--- a/fe/play-baseball-fe/pages/index.tsx
+++ b/fe/play-baseball-fe/pages/index.tsx
@@ -104,8 +104,8 @@ const MainPage: React.FC = () => {
 
       <Grid container spacing={3}>
         {items.map((item) => (
-          <Grid item xs={12} sm={6} md={4} lg={3} key={item.id}>
-            <Link href={`/exchange/${item.id}`} passHref>
+          <Grid item xs={12} sm={6} md={4} lg={3} key={item.url}>
+            <Link href={`${item.url}`} passHref>
               <Card
                 sx={{
                   height: "100%",

--- a/fe/play-baseball-fe/pages/index.tsx
+++ b/fe/play-baseball-fe/pages/index.tsx
@@ -1,3 +1,4 @@
+import React, { useState, useEffect, useCallback } from "react";
 import {
   Box,
   Grid,
@@ -8,57 +9,81 @@ import {
   Container,
 } from "@mui/material";
 import Link from "next/link";
-import SearchBar from "../components/SearchBar"
+import SearchBar from "../components/SearchBar";
+import axios from "axios";
+import { EXCHANGE } from "@/constants/endpoints";
+import debounce from "lodash/debounce"; // lodash를 올바르게 import
+
+interface Item {
+  id: number;
+  title: string;
+  price: number;
+  imageUrl: string;
+}
 
 const MainPage: React.FC = () => {
-    const handleSearch = (searchTerm: string) => {
-    console.log('Searching for:', searchTerm);
-    // Add your search logic here
+  const [items, setItems] = useState<Item[]>([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const handleSearch = (searchTerm: string) => {
+    console.log("Searching for:", searchTerm);
   };
-  const items = [
-    {
-      id: 1,
-      title: "아이템 1",
-      price: "1,430,000 원",
-      imageUrl: "/exchange/image.jpg",
-      link: "/exchange/1",
-    },
-    {
-      id: 2,
-      title: "아이템 2",
-      price: "90,000 원",
-      imageUrl: "/exchange/image2.jpg",
-      link: "/product/2",
-    },
-    {
-      id: 3,
-      title: "아이템 3",
-      price: "70,000 원",
-      imageUrl: "/exchange/image3.jpg",
-      link: "/product/3",
-    },
-    {
-      id: 4,
-      title: "아이템 4",
-      price: "19,000 원",
-      imageUrl: "/exchange/image2.jpg",
-      link: "/product/4",
-    },
-    {
-      id: 5,
-      title: "아이템 5",
-      price: "420,000 원",
-      imageUrl: "/exchange/image.jpg",
-      link: "/product/5",
-    },
-  ];
+
+  // 데이터 불러오기
+  const fetchItems = async (pageNumber: number) => {
+    setLoading(true);
+    try {
+      const response = await axios.get(`${EXCHANGE}?page=${pageNumber}`);
+      const newItems = response.data.data.content.map((item: any) => ({
+        id: item.id,
+        title: item.title,
+        price: item.price,
+        imageUrl: item.images[0]?.url,
+      }));
+      setItems((prevItems) => [...prevItems, ...newItems]);
+      setHasMore(!response.data.data.last);
+    } catch (error) {
+      console.error("Error fetching items:", error);
+    }
+    setLoading(false);
+  };
+
+  // 페이지 처음 로드 시 첫 데이터 요청
+  useEffect(() => {
+    fetchItems(page);
+  }, [page]);
+
+  // 스크롤 이벤트 핸들러
+  const handleScroll = useCallback(
+    debounce(() => {
+      if (
+        window.innerHeight + document.documentElement.scrollTop >=
+        document.documentElement.offsetHeight - 50
+      ) {
+        if (!loading && hasMore) {
+          setPage((prevPage) => prevPage + 1); // 다음 페이지 요청
+        }
+      }
+    }, 300), // 300ms 동안 이벤트가 연속적으로 발생하지 않도록 제한.
+    [loading, hasMore]
+  );
+
+  // 스크롤 이벤트 감지
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll]);
 
   return (
-    
     <Container maxWidth="lg" sx={{ py: 3 }}>
       <div className="width-[70%]">
-    <SearchBar onSearch={handleSearch}></SearchBar>
-    </div>
+        <SearchBar onSearch={handleSearch} />
+      </div>
+
       <Box
         sx={{
           width: "100%",
@@ -78,7 +103,7 @@ const MainPage: React.FC = () => {
       <Grid container spacing={3}>
         {items.map((item) => (
           <Grid item xs={12} sm={6} md={4} lg={3} key={item.id}>
-            <Link href={item.link} passHref>
+            <Link href={`/exchange/${item.id}`} passHref>
               <Card
                 sx={{
                   height: "100%",
@@ -100,7 +125,7 @@ const MainPage: React.FC = () => {
                     {item.title}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
-                    {item.price}
+                    {item.price.toLocaleString()} 원
                   </Typography>
                 </CardContent>
               </Card>
@@ -108,6 +133,12 @@ const MainPage: React.FC = () => {
           </Grid>
         ))}
       </Grid>
+
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 3 }}>
+          <Typography>Loading...</Typography>
+        </Box>
+      )}
     </Container>
   );
 };

--- a/fe/play-baseball-fe/pages/index.tsx
+++ b/fe/play-baseball-fe/pages/index.tsx
@@ -12,7 +12,7 @@ import Link from "next/link";
 import SearchBar from "../components/SearchBar";
 import axios from "axios";
 import { EXCHANGE } from "@/constants/endpoints";
-import debounce from "lodash/debounce"; // lodash를 올바르게 import
+import debounce from "lodash/debounce";
 
 interface Item {
   id: number;

--- a/fe/play-baseball-fe/pages/index.tsx
+++ b/fe/play-baseball-fe/pages/index.tsx
@@ -15,10 +15,11 @@ import { EXCHANGE } from "@/constants/endpoints";
 import debounce from "lodash/debounce";
 
 interface Item {
-  id: number;
   title: string;
   price: number;
+  url: string;
   imageUrl: string;
+  updatedAt: string;
 }
 
 const MainPage: React.FC = () => {
@@ -37,10 +38,11 @@ const MainPage: React.FC = () => {
     try {
       const response = await axios.get(`${EXCHANGE}?page=${pageNumber}`);
       const newItems = response.data.data.content.map((item: any) => ({
-        id: item.id,
         title: item.title,
         price: item.price,
-        imageUrl: item.images[0]?.url,
+        url: item.url,
+        imageUrl: item.imageUrl,
+        updatedAt: item.updatedAt,
       }));
       setItems((prevItems) => [...prevItems, ...newItems]);
       setHasMore(!response.data.data.last);

--- a/src/main/java/org/example/spring/controller/ExchangeController.java
+++ b/src/main/java/org/example/spring/controller/ExchangeController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.exchange.dto.ExchangeAddRequestDto;
+import org.example.spring.domain.exchange.dto.ExchangeDetailResponseDto;
 import org.example.spring.domain.exchange.dto.ExchangeModifyRequestDto;
 import org.example.spring.domain.exchange.dto.ExchangeResponseDto;
 import org.example.spring.exception.InvalidTokenException;
@@ -143,9 +144,9 @@ public class ExchangeController {
    * @return 게시물 id와 일치하는 게시물 정보
    */
   @GetMapping("/{id}")
-  public ResponseEntity<ApiResponseDto<ExchangeResponseDto>> getExchangeDetail(
+  public ResponseEntity<ApiResponseDto<ExchangeDetailResponseDto>> getExchangeDetail(
       @PathVariable Long id) {
-    ExchangeResponseDto response = exchangeService.getExchangeDetail(id);
+    ExchangeDetailResponseDto response = exchangeService.getExchangeDetail(id);
     return ResponseEntity.status(HttpStatus.OK)
         .body(ApiResponseDto.success("회원의 게시물 조회 성공", response));
   }

--- a/src/main/java/org/example/spring/controller/ExchangeController.java
+++ b/src/main/java/org/example/spring/controller/ExchangeController.java
@@ -131,4 +131,18 @@ public class ExchangeController {
     return ResponseEntity.status(HttpStatus.OK)
         .body(ApiResponseDto.success("회원의 게시물 조회 성공", responses));
   }
+
+  /**
+   * 특정 게시물 1개를 조회합니다.
+   *
+   * @param id 게시물 id
+   * @return 게시물 id와 일치하는 게시물 정보
+   */
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponseDto<ExchangeResponseDto>> getExchangeDetail(
+      @PathVariable Long id) {
+    ExchangeResponseDto response = exchangeService.getExchangeDetail(id);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(ApiResponseDto.success("회원의 게시물 조회 성공", response));
+  }
 }

--- a/src/main/java/org/example/spring/controller/ExchangeController.java
+++ b/src/main/java/org/example/spring/controller/ExchangeController.java
@@ -31,9 +31,10 @@ public class ExchangeController {
   /**
    * 중고거래 게시물을 추가합니다.
    *
+   * @param request 회원 여부 확인용 http request
    * @param exchangeAddRequestDto 게시글 추가 요청 자료 DTO
    * @param images 게시글에 포함된 이미지
-   * @return 생성된 게시물 응답 DTO
+   * @return 처리 결과에 따른 응답을 반환합니다.
    */
   @PostMapping
   public ResponseEntity<ApiResponseDto<ExchangeResponseDto>> addExchange(
@@ -55,9 +56,11 @@ public class ExchangeController {
   /**
    * 기존에 작성되어 있던 중고거래 게시물 내용을 수정합니다.
    *
+   * @param request 수정 권한 확인용 http request
    * @param id DB에 등록된 수정할 게시글 id
-   * @param request 게시글 수정 요청 자료 DTO
-   * @return 수정된 게시물 응답 DTO
+   * @param exchangeModifyRequestDto 수정할 게시물 내용
+   * @param images 수정할 게시물 이미지
+   * @return 처리 결과에 따른 응답을 반환합니다.
    */
   @PutMapping("/{id}")
   public ResponseEntity<ApiResponseDto<ExchangeResponseDto>> modifyExchange(
@@ -80,6 +83,7 @@ public class ExchangeController {
   /**
    * 기존에 작성되어 있던 중고거래 게시물을 삭제합니다. 삭제는 Soft delete 방식으로 이루어지며, DB에 등록된 deleted_at 내용에 값을 추가합니다.
    *
+   * @param request 삭제 처리 권한 확인용 http request
    * @param id DB에 등록된 삭제할 게시글 id
    * @return 응답에 상태에 따른 ResponseDto
    */
@@ -138,15 +142,16 @@ public class ExchangeController {
   }
 
   /**
-   * 특정 게시물 1개를 조회합니다.
+   * 특정 게시물 1개 및 작성자 여부를 조회합니다.
    *
+   * @param request 작성자 여부 조회
    * @param id 게시물 id
-   * @return 게시물 id와 일치하는 게시물 정보
+   * @return 게시물 id와 일치하는 게시물 정보와 작성자 여부
    */
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponseDto<ExchangeDetailResponseDto>> getExchangeDetail(
-      @PathVariable Long id) {
-    ExchangeDetailResponseDto response = exchangeService.getExchangeDetail(id);
+      HttpServletRequest request, @PathVariable Long id) {
+    ExchangeDetailResponseDto response = exchangeService.getExchangeDetail(request, id);
     return ResponseEntity.status(HttpStatus.OK)
         .body(ApiResponseDto.success("회원의 게시물 조회 성공", response));
   }

--- a/src/main/java/org/example/spring/controller/ExchangeController.java
+++ b/src/main/java/org/example/spring/controller/ExchangeController.java
@@ -145,4 +145,22 @@ public class ExchangeController {
     return ResponseEntity.status(HttpStatus.OK)
         .body(ApiResponseDto.success("회원의 게시물 조회 성공", response));
   }
+
+  /**
+   * 제목에 대한 검색 기능입니다. 제목이 키워드에 포함되어있는 게시물 목록을 조회합니다.
+   *
+   * @param keyword 검색에 사용할 키워드.
+   * @param page 게시물이 포함된 페이지
+   * @param size 한 번에 렌더링할 게시물 개수
+   * @return 제목이 키워드에 포함되어있는 게시물 목록을 page와 size에 따라 반환
+   */
+  @GetMapping("/search")
+  public ResponseEntity<ApiResponseDto<Page<ExchangeResponseDto>>> getExchangesByTitleContaining(
+      @RequestParam(required = false, defaultValue = "") String keyword,
+      @RequestParam(required = false, defaultValue = PAGE_DEFAULT) int page,
+      @RequestParam(required = false, defaultValue = PAGE_SIZE_DEFAULT) int size) {
+    Page<ExchangeResponseDto> responses =
+        exchangeService.getExchangesByTitleContaining(keyword, page, size);
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success("검색 성공", responses));
+  }
 }

--- a/src/main/java/org/example/spring/controller/ExchangeController.java
+++ b/src/main/java/org/example/spring/controller/ExchangeController.java
@@ -6,6 +6,7 @@ import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.exchange.dto.ExchangeAddRequestDto;
 import org.example.spring.domain.exchange.dto.ExchangeDetailResponseDto;
 import org.example.spring.domain.exchange.dto.ExchangeModifyRequestDto;
+import org.example.spring.domain.exchange.dto.ExchangeNavigationResponseDto;
 import org.example.spring.domain.exchange.dto.ExchangeResponseDto;
 import org.example.spring.exception.InvalidTokenException;
 import org.example.spring.service.ExchangeService;
@@ -54,6 +55,88 @@ public class ExchangeController {
   }
 
   /**
+   * 작성된 글 중 삭제처리되지 않은 모든 글 목록을 조회합니다.
+   *
+   * @param page 게시물이 포함된 페이지
+   * @param size 한 번에 렌더링할 게시물 개수
+   * @return 게시글 목록을 page와 size에 따라 반환
+   */
+  @GetMapping
+  public ResponseEntity<ApiResponseDto<Page<ExchangeNavigationResponseDto>>> getAllExchanges(
+      @RequestParam(required = false, defaultValue = PAGE_DEFAULT) int page,
+      @RequestParam(required = false, defaultValue = PAGE_SIZE_DEFAULT) int size) {
+    Page<ExchangeNavigationResponseDto> responses = exchangeService.getAllExchanges(page, size);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(ApiResponseDto.success("모든 게시물 조회 성공.", responses));
+  }
+
+  /**
+   * 최근에 작성된 게시물 5개를 조회합니다.
+   *
+   * @return Exchange table 에서 Created_at을 내림차순으로 정렬한 row 5개
+   */
+  @GetMapping("/five")
+  public ResponseEntity<ApiResponseDto<List<ExchangeNavigationResponseDto>>>
+      getLatestFiveExchanges() {
+    List<ExchangeNavigationResponseDto> responses = exchangeService.getLatestFiveExchanges();
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(ApiResponseDto.success("게시물 5개 조회 성공.", responses));
+  }
+
+  /**
+   * 특정 회원이 작성한 게시물 목록을 조회합니다.
+   *
+   * @param memberId 대상 회원 id
+   * @param page 게시물이 포함된 페이지
+   * @param size 한 번에 렌더링할 게시물 개수
+   * @return memberId와 일치하는 게시글 목록을 page와 size에 따라 반환
+   */
+  @GetMapping("/{memberId}")
+  public ResponseEntity<ApiResponseDto<Page<ExchangeNavigationResponseDto>>> getMyExchanges(
+      @PathVariable Long memberId,
+      @RequestParam(required = false, defaultValue = PAGE_DEFAULT) int page,
+      @RequestParam(required = false, defaultValue = PAGE_SIZE_DEFAULT) int size) {
+    Page<ExchangeNavigationResponseDto> responses =
+        exchangeService.getUserExchanges(memberId, page, size);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(ApiResponseDto.success("회원의 게시물 조회 성공", responses));
+  }
+
+  /**
+   * 제목에 대한 검색 기능입니다. 제목이 키워드에 포함되어있는 게시물 목록을 조회합니다.
+   *
+   * @param keyword 검색에 사용할 키워드.
+   * @param page 게시물이 포함된 페이지
+   * @param size 한 번에 렌더링할 게시물 개수
+   * @return 제목이 키워드에 포함되어있는 게시물 목록을 page와 size에 따라 반환
+   */
+  @GetMapping("/search")
+  public ResponseEntity<ApiResponseDto<Page<ExchangeNavigationResponseDto>>>
+      getExchangesByTitleContaining(
+          @RequestParam(required = false, defaultValue = "") String keyword,
+          @RequestParam(required = false, defaultValue = PAGE_DEFAULT) int page,
+          @RequestParam(required = false, defaultValue = PAGE_SIZE_DEFAULT) int size) {
+    Page<ExchangeNavigationResponseDto> responses =
+        exchangeService.getExchangesByTitleContaining(keyword, page, size);
+    return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success("검색 성공", responses));
+  }
+
+  /**
+   * 특정 게시물 1개 및 작성자 여부를 조회합니다.
+   *
+   * @param request 작성자 여부 조회
+   * @param id 게시물 id
+   * @return 게시물 id와 일치하는 게시물 정보와 작성자 여부
+   */
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponseDto<ExchangeDetailResponseDto>> getExchangeDetail(
+      HttpServletRequest request, @PathVariable Long id) {
+    ExchangeDetailResponseDto response = exchangeService.getExchangeDetail(request, id);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(ApiResponseDto.success("회원의 게시물 조회 성공", response));
+  }
+
+  /**
    * 기존에 작성되어 있던 중고거래 게시물 내용을 수정합니다.
    *
    * @param request 수정 권한 확인용 http request
@@ -93,84 +176,5 @@ public class ExchangeController {
     exchangeService.deleteExchange(request, id);
     return ResponseEntity.status(HttpStatus.OK)
         .body(ApiResponseDto.success("게시물이 삭제 되었습니다.", null));
-  }
-
-  /**
-   * 작성된 글 중 삭제처리되지 않은 모든 글 목록을 조회합니다.
-   *
-   * @param page 게시물이 포함된 페이지
-   * @param size 한 번에 렌더링할 게시물 개수
-   * @return 게시글 목록을 page와 size에 따라 반환
-   */
-  @GetMapping
-  public ResponseEntity<ApiResponseDto<Page<ExchangeResponseDto>>> getAllExchanges(
-      @RequestParam(required = false, defaultValue = PAGE_DEFAULT) int page,
-      @RequestParam(required = false, defaultValue = PAGE_SIZE_DEFAULT) int size) {
-    Page<ExchangeResponseDto> responses = exchangeService.getAllExchanges(page, size);
-    return ResponseEntity.status(HttpStatus.OK)
-        .body(ApiResponseDto.success("모든 게시물 조회 성공.", responses));
-  }
-
-  /**
-   * 최근에 작성된 게시물 5개를 조회합니다.
-   *
-   * @return Exchange table 에서 Created_at을 내림차순으로 정렬한 row 5개
-   */
-  @GetMapping("/five")
-  public ResponseEntity<ApiResponseDto<List<ExchangeResponseDto>>> getLatestFiveExchanges() {
-    List<ExchangeResponseDto> responses = exchangeService.getLatestFiveExchanges();
-    return ResponseEntity.status(HttpStatus.OK)
-        .body(ApiResponseDto.success("게시물 5개 조회 성공.", responses));
-  }
-
-  /**
-   * 특정 회원이 작성한 게시물 목록을 조회합니다.
-   *
-   * @param memberId 대상 회원 id
-   * @param page 게시물이 포함된 페이지
-   * @param size 한 번에 렌더링할 게시물 개수
-   * @return memberId와 일치하는 게시글 목록을 page와 size에 따라 반환
-   */
-  @GetMapping("/{memberId}")
-  public ResponseEntity<ApiResponseDto<Page<ExchangeResponseDto>>> getMyExchanges(
-      @PathVariable Long memberId,
-      @RequestParam(required = false, defaultValue = PAGE_DEFAULT) int page,
-      @RequestParam(required = false, defaultValue = PAGE_SIZE_DEFAULT) int size) {
-    Page<ExchangeResponseDto> responses = exchangeService.getUserExchanges(memberId, page, size);
-    return ResponseEntity.status(HttpStatus.OK)
-        .body(ApiResponseDto.success("회원의 게시물 조회 성공", responses));
-  }
-
-  /**
-   * 특정 게시물 1개 및 작성자 여부를 조회합니다.
-   *
-   * @param request 작성자 여부 조회
-   * @param id 게시물 id
-   * @return 게시물 id와 일치하는 게시물 정보와 작성자 여부
-   */
-  @GetMapping("/{id}")
-  public ResponseEntity<ApiResponseDto<ExchangeDetailResponseDto>> getExchangeDetail(
-      HttpServletRequest request, @PathVariable Long id) {
-    ExchangeDetailResponseDto response = exchangeService.getExchangeDetail(request, id);
-    return ResponseEntity.status(HttpStatus.OK)
-        .body(ApiResponseDto.success("회원의 게시물 조회 성공", response));
-  }
-
-  /**
-   * 제목에 대한 검색 기능입니다. 제목이 키워드에 포함되어있는 게시물 목록을 조회합니다.
-   *
-   * @param keyword 검색에 사용할 키워드.
-   * @param page 게시물이 포함된 페이지
-   * @param size 한 번에 렌더링할 게시물 개수
-   * @return 제목이 키워드에 포함되어있는 게시물 목록을 page와 size에 따라 반환
-   */
-  @GetMapping("/search")
-  public ResponseEntity<ApiResponseDto<Page<ExchangeResponseDto>>> getExchangesByTitleContaining(
-      @RequestParam(required = false, defaultValue = "") String keyword,
-      @RequestParam(required = false, defaultValue = PAGE_DEFAULT) int page,
-      @RequestParam(required = false, defaultValue = PAGE_SIZE_DEFAULT) int size) {
-    Page<ExchangeResponseDto> responses =
-        exchangeService.getExchangesByTitleContaining(keyword, page, size);
-    return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success("검색 성공", responses));
   }
 }

--- a/src/main/java/org/example/spring/controller/ExchangeController.java
+++ b/src/main/java/org/example/spring/controller/ExchangeController.java
@@ -80,7 +80,7 @@ public class ExchangeController {
    * 기존에 작성되어 있던 중고거래 게시물을 삭제합니다. 삭제는 Soft delete 방식으로 이루어지며, DB에 등록된 deleted_at 내용에 값을 추가합니다.
    *
    * @param id DB에 등록된 삭제할 게시글 id
-   * @return 삭제된 게시물 응답 DTO
+   * @return 응답에 상태에 따른 ResponseDto
    */
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponseDto<Void>> deleteExchange(
@@ -91,9 +91,11 @@ public class ExchangeController {
   }
 
   /**
-   * 작성되어 있는 모든 게시물을 조회합니다.
+   * 작성된 글 중 삭제처리되지 않은 모든 글 목록을 조회합니다.
    *
-   * @return 작성되어 있는 모든 게시물
+   * @param page 게시물이 포함된 페이지
+   * @param size 한 번에 렌더링할 게시물 개수
+   * @return 게시글 목록을 page와 size에 따라 반환
    */
   @GetMapping
   public ResponseEntity<ApiResponseDto<Page<ExchangeResponseDto>>> getAllExchanges(
@@ -117,10 +119,12 @@ public class ExchangeController {
   }
 
   /**
-   * 특정 회원이 작성한 게시물을 조회합니다.
+   * 특정 회원이 작성한 게시물 목록을 조회합니다.
    *
-   * @param memberId 특정 회원 id
-   * @return memberId와 일치하는 게시글 목록
+   * @param memberId 대상 회원 id
+   * @param page 게시물이 포함된 페이지
+   * @param size 한 번에 렌더링할 게시물 개수
+   * @return memberId와 일치하는 게시글 목록을 page와 size에 따라 반환
    */
   @GetMapping("/{memberId}")
   public ResponseEntity<ApiResponseDto<Page<ExchangeResponseDto>>> getMyExchanges(

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeAddRequestDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeAddRequestDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ExchangeAddRequestDto {
-  private String title;
-  private int price;
-  private String content;
+  private final String title;
+  private final int price;
+  private final String content;
 }

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
@@ -23,18 +23,12 @@ public class ExchangeDetailResponseDto {
   private List<ExchangeImageResponseDto> images;
 
   public static ExchangeDetailResponseDto fromExchange(Exchange exchange) {
-    // 이미지가 없을 경우 기본 이미지 url 변환
-    String defaultImageUrl =
-        "http://localhost:8080/uploads/c2ba53a3-c5d2-458d-beea-584384ad88c1_ad.jpg";
-
     List<ExchangeImageResponseDto> images = new ArrayList<>();
     if (!exchange.getImages().isEmpty()) {
       images =
           exchange.getImages().stream()
               .map(ExchangeImageResponseDto::fromImage)
               .collect(Collectors.toList());
-    } else {
-      images = List.of(ExchangeImageResponseDto.builder().url(defaultImageUrl).build());
     }
 
     return ExchangeDetailResponseDto.builder()

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
@@ -18,10 +18,12 @@ public class ExchangeDetailResponseDto {
   private final int regularPrice;
   private final String content;
   private final int viewCount;
-  private SalesStatus status;
-  private Timestamp updatedAt;
-  private List<ExchangeImageResponseDto> images;
-  private boolean isWriter;
+  private final SalesStatus status;
+  private final Timestamp updatedAt;
+  private final List<ExchangeImageResponseDto> images;
+  private final String writer;
+  private final List<ExchangeNavigationResponseDto> recentExchangesByMember;
+  private final boolean isWriter;
 
   public ExchangeDetailResponseDtoBuilder toBuilder() {
     return ExchangeDetailResponseDto.builder()

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
@@ -21,6 +21,19 @@ public class ExchangeDetailResponseDto {
   private SalesStatus status;
   private Timestamp updatedAt;
   private List<ExchangeImageResponseDto> images;
+  private boolean isWriter;
+
+  public ExchangeDetailResponseDtoBuilder toBuilder() {
+    return ExchangeDetailResponseDto.builder()
+        .title(this.title)
+        .price(this.price)
+        .regularPrice(this.regularPrice)
+        .content(this.content)
+        .viewCount(this.viewCount)
+        .status(this.status)
+        .updatedAt(this.updatedAt)
+        .images(this.images);
+  }
 
   public static ExchangeDetailResponseDto fromExchange(Exchange exchange) {
     List<ExchangeImageResponseDto> images = new ArrayList<>();

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
@@ -37,7 +37,10 @@ public class ExchangeDetailResponseDto {
         .images(this.images);
   }
 
-  public static ExchangeDetailResponseDto fromExchange(Exchange exchange) {
+  public static ExchangeDetailResponseDto fromExchange(
+      Exchange exchange,
+      List<ExchangeNavigationResponseDto> recentExchangesByMember,
+      boolean isWriter) {
     List<ExchangeImageResponseDto> images = new ArrayList<>();
     if (!exchange.getImages().isEmpty()) {
       images =
@@ -55,6 +58,9 @@ public class ExchangeDetailResponseDto {
         .status(exchange.getStatus())
         .updatedAt(exchange.getUpdatedAt())
         .images(images)
+        .writer(exchange.getMember().getNickname())
+        .recentExchangesByMember(recentExchangesByMember)
+        .isWriter(isWriter)
         .build();
   }
 }

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
@@ -10,12 +10,9 @@ import org.example.spring.constants.SalesStatus;
 import org.example.spring.domain.exchange.Exchange;
 import org.example.spring.domain.exchangeImage.dto.ExchangeImageResponseDto;
 
-/** 게시글 관련 요청을 보낸 후 응답을 받을 때 사용하는 Dto 관련 요청 목록: 생성, 조회, 수정 */
 @Getter
 @Builder
-public class ExchangeResponseDto {
-  private final Long id;
-  private final Long memberId;
+public class ExchangeDetailResponseDto {
   private final String title;
   private final int price;
   private final int regularPrice;
@@ -25,7 +22,7 @@ public class ExchangeResponseDto {
   private Timestamp updatedAt;
   private List<ExchangeImageResponseDto> images;
 
-  public static ExchangeResponseDto fromExchange(Exchange exchange) {
+  public static ExchangeDetailResponseDto fromExchange(Exchange exchange) {
     // 이미지가 없을 경우 기본 이미지 url 변환
     String defaultImageUrl =
         "http://localhost:8080/uploads/c2ba53a3-c5d2-458d-beea-584384ad88c1_ad.jpg";
@@ -40,9 +37,7 @@ public class ExchangeResponseDto {
       images = List.of(ExchangeImageResponseDto.builder().url(defaultImageUrl).build());
     }
 
-    return ExchangeResponseDto.builder()
-        .id(exchange.getId())
-        .memberId(exchange.getMember().getId())
+    return ExchangeDetailResponseDto.builder()
         .title(exchange.getTitle())
         .price(exchange.getPrice())
         .regularPrice(exchange.getRegularPrice())

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
@@ -1,5 +1,6 @@
 package org.example.spring.domain.exchange.dto;
 
+import java.sql.Timestamp;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.spring.domain.exchange.Exchange;
@@ -11,6 +12,7 @@ public class ExchangeNavigationResponseDto {
   private int price;
   private String url;
   private String imageUrl;
+  private Timestamp updatedAt;
 
   public static ExchangeNavigationResponseDto fromExchange(Exchange exchange) {
     String imageUrl = "";
@@ -23,6 +25,7 @@ public class ExchangeNavigationResponseDto {
         .price(exchange.getPrice())
         .url("https://www.ioshane.com/exchange/" + exchange.getId())
         .imageUrl(imageUrl)
+        .updatedAt(exchange.getUpdatedAt())
         .build();
   }
 }

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
@@ -1,0 +1,28 @@
+package org.example.spring.domain.exchange.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.spring.domain.exchange.Exchange;
+
+@Getter
+@Builder
+public class ExchangeNavigationResponseDto {
+  private String title;
+  private int price;
+  private String url;
+  private String imageUrl;
+
+  public static ExchangeNavigationResponseDto fromExchange(Exchange exchange) {
+    String imageUrl = "";
+    if (!exchange.getImages().isEmpty()) {
+      imageUrl = exchange.getImages().getFirst().getUrl();
+    }
+
+    return ExchangeNavigationResponseDto.builder()
+        .title(exchange.getTitle())
+        .price(exchange.getPrice())
+        .url("https://www.ioshane.com/exchange/" + exchange.getId())
+        .imageUrl(imageUrl)
+        .build();
+  }
+}

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
@@ -8,11 +8,11 @@ import org.example.spring.domain.exchange.Exchange;
 @Getter
 @Builder
 public class ExchangeNavigationResponseDto {
-  private String title;
-  private int price;
-  private String url;
-  private String imageUrl;
-  private Timestamp updatedAt;
+  private final String title;
+  private final int price;
+  private final String url;
+  private final String imageUrl;
+  private final Timestamp updatedAt;
 
   public static ExchangeNavigationResponseDto fromExchange(Exchange exchange) {
     String imageUrl = "";

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeResponseDto.java
@@ -21,9 +21,9 @@ public class ExchangeResponseDto {
   private final int regularPrice;
   private final String content;
   private final int viewCount;
-  private SalesStatus status;
-  private Timestamp updatedAt;
-  private List<ExchangeImageResponseDto> images;
+  private final SalesStatus status;
+  private final Timestamp updatedAt;
+  private final List<ExchangeImageResponseDto> images;
 
   public static ExchangeResponseDto fromExchange(Exchange exchange) {
     // 이미지가 없을 경우 기본 이미지 url 변환

--- a/src/main/java/org/example/spring/repository/ExchangeRepository.java
+++ b/src/main/java/org/example/spring/repository/ExchangeRepository.java
@@ -1,15 +1,20 @@
 package org.example.spring.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.example.spring.domain.exchange.Exchange;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-/** DeletedAt이 null인 게시물을 대상으로 글을 가져옵니다. 게시물 삭제는 Soft Delete를 사용합니다. */
+/**
+ * DeletedAt이 null인 게시물을 대상으로 글을 가져옵니다. 게시물 삭제는 Soft Delete를 사용합니다. 여러 개 게시물을 조회하는 메서드는 기본적으로 생성일 기준
+ * 내림차순으로 글을 가져옵니다.
+ */
 @Repository
 public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
+  // 삭제되지 않은 모든 글 조회
   Page<Exchange> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
 
   // 검색 키워드에 포함되어 있는 게시글 목록 조회
@@ -22,4 +27,6 @@ public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
   // 특정 회원이 작성한 게시글 조회
   Page<Exchange> findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(
       Long memberId, Pageable pageable);
+
+  Optional<Exchange> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/spring/repository/ExchangeRepository.java
+++ b/src/main/java/org/example/spring/repository/ExchangeRepository.java
@@ -10,14 +10,16 @@ import org.springframework.stereotype.Repository;
 /** DeletedAt이 null인 게시물을 대상으로 글을 가져옵니다. 게시물 삭제는 Soft Delete를 사용합니다. */
 @Repository
 public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
-  Page<Exchange> findByDeletedAtIsNull(Pageable pageable);
+  Page<Exchange> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
 
   // 검색 키워드에 포함되어 있는 게시글 목록 조회
-  Page<Exchange> findByTitleContainingAndDeletedAtIsNull(String title, Pageable pageable);
+  Page<Exchange> findByTitleContainingAndDeletedAtIsNullOrderByCreatedAtDesc(
+      String title, Pageable pageable);
 
   // 최근 5개의 게시글 조회
   List<Exchange> findTop5ByDeletedAtIsNullOrderByCreatedAtDesc();
 
   // 특정 회원이 작성한 게시글 조회
-  Page<Exchange> findByMemberIdAndDeletedAtIsNull(Long memberId, Pageable pageable);
+  Page<Exchange> findByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(
+      Long memberId, Pageable pageable);
 }


### PR DESCRIPTION
## 📝 PR 설명
Exchange 관련 페이지 API 연결과 관련 BE 내용 메서드를 추가했습니다.

<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->
### BE
- ✨ 검색 기능 Controller 엔드포인트 빠져있던 부분 추가
- ✨ ExchangeDetailResponseDto 내용 추가
- ✨ ExchangeNavigationResponseDto 추가
- 📚 Exchange 관련 내용 JavaDoc 수정


### FE
- ✨ 메인 페이지 조회 API 연결
- ✨ 게시물 상세 페이지 수정, 삭제버튼 추가
- ✨ 게시물 상세 페이지 조회, 수정, 삭제 API 연결
- ✨ 게시물 수정 페이지 추가
- ✨ 게시물 수정 페이지 진입 시 수정한 글에 해당하는 원본 내용 채우도록 API 연결
- ✨ 게시물 수정 페이지 작성 버튼 API 연결

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #180
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트
- 현재 Data가 사라지고, BE와 통신이 원활하지 않은 버전이라 Merge 이후 테스트가 필요합니다.
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->