### PR TITLE
Fix: 게시물 상세조회 링크 www 제거, 링크 프로파일에 따라 작동하도록 yml 작성

### DIFF
--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeNavigationResponseDto.java
@@ -14,7 +14,8 @@ public class ExchangeNavigationResponseDto {
   private final String imageUrl;
   private final Timestamp updatedAt;
 
-  public static ExchangeNavigationResponseDto fromExchange(Exchange exchange) {
+  public static ExchangeNavigationResponseDto fromExchange(
+      Exchange exchange, String frontendBaseUrl) {
     String imageUrl = "";
     if (!exchange.getImages().isEmpty()) {
       imageUrl = exchange.getImages().getFirst().getUrl();
@@ -23,7 +24,7 @@ public class ExchangeNavigationResponseDto {
     return ExchangeNavigationResponseDto.builder()
         .title(exchange.getTitle())
         .price(exchange.getPrice())
-        .url("https://www.ioshane.com/exchange/" + exchange.getId())
+        .url(frontendBaseUrl + exchange.getId())
         .imageUrl(imageUrl)
         .updatedAt(exchange.getUpdatedAt())
         .build();

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -76,6 +76,7 @@ file:
 
 app:
   base-url: https://api.ioshane.com
+  fe-url: https://ioshane.com
 
 #server:
 #  forward-headers-strategy: native


### PR DESCRIPTION
## 📝 PR 설명
게시물 상세조회 링크가 제대로 동작하지 않는 문제를 수정하고, 하드코딩 되어있던 영역읋 수정했습니다.
<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- 🐛 ExchangeNavigationResponseDto Builder 내용에서 www 내용 제거
- 🐛 게시물 상세조회 링크 하드코딩 영역 제거

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #201
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->