### PR TITLE
Fix: DockerFile 환경변수 이름 변경 NEC -> NEXT_PUBLIC_NEC

### DIFF
--- a/fe/play-baseball-fe/Dockerfile
+++ b/fe/play-baseball-fe/Dockerfile
@@ -21,10 +21,10 @@ FROM base AS builder
 WORKDIR /app
 
 ARG NEXT_PUBLIC_API_URL
-ARG NEC
+ARG NEXT_PUBLIC_NEC
 
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV NEC=${NEC}
+ENV NEXT_PUBLIC_NEC=${NEC}
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .


### PR DESCRIPTION
## 📝 PR 설명
DockerFile에 작성된 환경변수 NEC는 클라이언트 환경에서 접근이 불가능한 환경 변수입니다.
이를 사용하는 관련 로직에 문제가 생겨 이를 NEXT_PUBLIC_NEC로 변경합니다.
<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- 🔧 DockerFile 내용 변경

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [ ] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #252
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->