### PR TITLE
#254 게시물 상세 페이지 내부 좋아요 기능 연동

### DIFF
--- a/fe/play-baseball-fe/constants/endpoints.tsx
+++ b/fe/play-baseball-fe/constants/endpoints.tsx
@@ -31,6 +31,7 @@ export const EXCHANGE_GET_ALL: string = `${EXCHANGE}`;
 export const EXCHANGE_GET_LATEST_FIVE: string = `${EXCHANGE}/five`;
 export const EXCHANGE_MODIFY_SALES_STATUS: string = `${EXCHANGE}/{id}`;
 export const EXCHANGE_GET_MY: string = `${EXCHANGE}/{memberId}`;
+export const EXCHANGE_LIKE: string = `${REQUEST_URL}/likes`;
 
 // Review Endpoints
 export const REVIEW: string = `${REQUEST_URL}/reviews`;

--- a/fe/play-baseball-fe/pages/exchange/[id].tsx
+++ b/fe/play-baseball-fe/pages/exchange/[id].tsx
@@ -13,13 +13,19 @@ import {
   Modal,
 } from "@mui/material";
 import axios from "axios";
-import { ArrowBack, ArrowForward } from "@mui/icons-material";
+import {
+  ArrowBack,
+  ArrowForward,
+  Favorite,
+  FavoriteBorder,
+  Visibility,
+} from "@mui/icons-material";
 import Image from "next/image";
 import Wrapper from "../../components/Wrapper";
 import { useRouter } from "next/router";
-import { DEFAULT_IMAGE, EXCHANGE } from "@/constants/endpoints";
+import { DEFAULT_IMAGE, EXCHANGE, EXCHANGE_LIKE } from "@/constants/endpoints";
 
-interface Image {
+interface ImageType {
   url: string;
   id: number;
 }
@@ -45,12 +51,14 @@ interface ExchangeDetailResponseDto {
   viewCount: number;
   status: "SALE" | "COMPLETE";
   updatedAt: string;
-  images: Image[];
+  images: ImageType[];
   writer: string;
   recentExchangesByMember: RecentExchange[];
   isWriter: "TRUE" | "FALSE";
   reviewCount: number;
   average: number;
+  likeCount: number;
+  isLike: boolean;
 }
 
 const ItemDetail: React.FC = () => {
@@ -60,6 +68,8 @@ const ItemDetail: React.FC = () => {
   const [exchangeData, setExchangeData] =
     useState<ExchangeDetailResponseDto | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [isLike, setIsLike] = useState<boolean>(false);
+  const [likeCount, setLikeCount] = useState<number>(0);
   const router = useRouter();
   const { id } = router.query;
   const token =
@@ -67,9 +77,10 @@ const ItemDetail: React.FC = () => {
       ? localStorage.getItem("Authorization")
       : null;
 
+  // 데이터 가져오는 함수
   useEffect(() => {
     const fetchExchangeData = async () => {
-      if (!id) return; // id가 없는 경우 일찍 반환
+      if (!id) return; // id가 없는 경우 바로 반환
       try {
         const response = await axios.get<
           ApiResponse<ExchangeDetailResponseDto>
@@ -79,8 +90,10 @@ const ItemDetail: React.FC = () => {
           },
           withCredentials: true,
         });
-        console.log(response);
+
         setExchangeData(response.data.data);
+        setIsLike(response.data.data.isLike);
+        setLikeCount(response.data.data.likeCount);
       } catch (error) {
         router.push({
           pathname: "/result",
@@ -99,12 +112,14 @@ const ItemDetail: React.FC = () => {
     if (id) fetchExchangeData(); // id가 존재할 때만 API 호출
   }, [id, router, token]);
 
+  // 로딩 상태 변경
   useEffect(() => {
     if (exchangeData) {
       setLoading(false);
     }
-  }, [exchangeData]); // exchangeData가 변경될 때마다 실행
+  }, [exchangeData]);
 
+  // 이전 이미지로 변경
   const handlePrev = () => {
     if (exchangeData?.images?.length) {
       setCurrentIndex(
@@ -115,6 +130,7 @@ const ItemDetail: React.FC = () => {
     }
   };
 
+  // 다음 이미지로 변경
   const handleNext = () => {
     if (exchangeData?.images?.length) {
       setCurrentIndex(
@@ -123,20 +139,30 @@ const ItemDetail: React.FC = () => {
     }
   };
 
-  const handleMouseEnter = () => {
-    setHover(true);
+  // 찜 토글
+  const toggleLike = async () => {
+    try {
+      const response = await axios.post(
+        `${EXCHANGE_LIKE}`,
+        {
+          exchangeId: id,
+        },
+        {
+          headers: {
+            Authorization: token,
+          },
+          withCredentials: true,
+        }
+      );
+      setIsLike(!isLike);
+      //setLikeCount(isLike ? likeCount - 1 : likeCount + 1);
+    } catch (error) {
+      console.error("찜 토글 중 오류 발생:", error);
+    }
   };
 
-  const handleMouseLeave = () => {
-    setHover(false);
-  };
-
+  // 삭제 처리 함수
   const handleDelete = async () => {
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem("Authorization")
-        : null;
-
     try {
       await axios.delete(`${EXCHANGE}/${id}`, {
         headers: {
@@ -179,19 +205,16 @@ const ItemDetail: React.FC = () => {
       <Wrapper>
         <Container maxWidth="lg" style={{ marginTop: "20px" }}>
           <Grid container spacing={2}>
-            {/* Gallery */}
+            {/* 이미지 갤러리 */}
             <Grid item xs={12} md={6}>
               <Box
                 position="relative"
                 display="flex"
                 flexDirection="column"
                 alignItems="center"
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
-                sx={{
-                  width: "100%",
-                  maxWidth: "100%",
-                }}
+                onMouseEnter={() => setHover(true)}
+                onMouseLeave={() => setHover(false)}
+                sx={{ width: "100%", maxWidth: "100%" }}
               >
                 <Box
                   display="flex"
@@ -200,8 +223,8 @@ const ItemDetail: React.FC = () => {
                   position="relative"
                   sx={{
                     width: "100%",
-                    aspectRatio: "1 / 1", // 원하는 비율을 설정할 수 있음
-                    overflow: "hidden", // 이미지가 잘릴 수 있음
+                    aspectRatio: "1 / 1",
+                    overflow: "hidden",
                   }}
                 >
                   <Fade in={hover}>
@@ -223,15 +246,15 @@ const ItemDetail: React.FC = () => {
                     <Image
                       src={exchangeData.images[currentIndex]?.url}
                       alt={exchangeData.images[currentIndex]?.id.toString()}
-                      layout="fill" // 컨테이너에 맞춰 이미지를 채움
-                      objectFit="cover" // 이미지 비율 유지하며 컨테이너를 채움
+                      layout="fill"
+                      objectFit="cover"
                     />
                   ) : (
                     <Image
                       src={DEFAULT_IMAGE}
-                      alt={"Default image"}
-                      layout="fill" // 컨테이너에 맞춰 이미지를 채움
-                      objectFit="cover" // 이미지 비율 유지하며 컨테이너를 채움
+                      alt="Default image"
+                      layout="fill"
+                      objectFit="cover"
                     />
                   )}
 
@@ -251,8 +274,7 @@ const ItemDetail: React.FC = () => {
                   </Fade>
                 </Box>
 
-                {/* Indicators */}
-
+                {/* 이미지 인디케이터 */}
                 <Box display="flex" justifyContent="center" mt={1}>
                   {exchangeData?.images?.length > 0 ? (
                     exchangeData.images.map((_, index) => (
@@ -279,7 +301,7 @@ const ItemDetail: React.FC = () => {
               </Box>
             </Grid>
 
-            {/* Product Info */}
+            {/* 상품 정보 */}
             <Grid item xs={12} md={6}>
               <Paper elevation={3} sx={{ padding: "20px" }}>
                 <Typography variant="h5">
@@ -300,8 +322,7 @@ const ItemDetail: React.FC = () => {
                 <Divider sx={{ margin: "20px 0" }} />
                 <Typography variant="body1">
                   이 상품의 정가는{" "}
-                  {exchangeData?.regularPrice?.toLocaleString() || "0"}원
-                  입니다.
+                  {exchangeData?.regularPrice?.toLocaleString() || "0"}원입니다.
                 </Typography>
                 <Divider sx={{ margin: "20px 0" }} />
                 <Button variant="contained" fullWidth>
@@ -334,19 +355,37 @@ const ItemDetail: React.FC = () => {
               </Paper>
             </Grid>
 
-            {/* Details */}
+            {/* 상품 상세 정보 */}
             <Grid item xs={12} md={6}>
               <Paper elevation={3} sx={{ padding: "20px" }}>
                 <Typography variant="h4">상품 정보</Typography>
-                <Typography color="textSecondary" sx={{ marginTop: "10px" }}>
-                  작성일:{" "}
-                  {exchangeData?.updatedAt
-                    ? new Date(exchangeData.updatedAt).toLocaleDateString()
-                    : "N/A"}
-                </Typography>
-                <Typography color="textSecondary">
-                  조회: {exchangeData?.viewCount || 0}
-                </Typography>
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  sx={{ marginTop: "10px" }}
+                >
+                  {/* 조회수 표시 */}
+                  <Box display="flex" alignItems="center" sx={{ mr: 2 }}>
+                    <Visibility sx={{ fontSize: 16, mr: 0.5 }} />
+                    <Typography color="textSecondary">
+                      {exchangeData?.viewCount || 0}
+                    </Typography>
+                  </Box>
+
+                  {/* 찜 버튼과 찜 개수 표시 */}
+                  <Box display="flex" alignItems="center">
+                    <IconButton onClick={toggleLike} sx={{ p: 0 }}>
+                      {isLike ? (
+                        <Favorite sx={{ color: "red" }} />
+                      ) : (
+                        <FavoriteBorder sx={{ color: "gray" }} />
+                      )}
+                    </IconButton>
+                    <Typography color="textSecondary" sx={{ ml: 0.5 }}>
+                      {likeCount}
+                    </Typography>
+                  </Box>
+                </Box>
                 <Divider sx={{ margin: "20px 0" }} />
                 <Typography variant="body1">
                   {exchangeData?.content || "상품 설명이 없습니다."}
@@ -354,27 +393,25 @@ const ItemDetail: React.FC = () => {
               </Paper>
             </Grid>
 
-            {/* Seller Info */}
+            {/* 판매자 정보 */}
             <Grid item xs={12} md={6}>
               <Paper elevation={3} sx={{ padding: "20px" }}>
                 <Typography variant="h6">
                   {exchangeData?.writer || "판매자 정보"}
                 </Typography>
                 <Box display="flex" alignItems="center">
-                  <Box display="flex" alignItems="center">
-                    <Rating
-                      value={exchangeData.average}
-                      precision={0.1}
-                      readOnly
-                    />
-                    <Typography
-                      variant="body2"
-                      color="textSecondary"
-                      sx={{ marginLeft: "5px" }}
-                    >
-                      ({exchangeData.reviewCount})
-                    </Typography>
-                  </Box>
+                  <Rating
+                    value={exchangeData.average}
+                    precision={0.1}
+                    readOnly
+                  />
+                  <Typography
+                    variant="body2"
+                    color="textSecondary"
+                    sx={{ marginLeft: "5px" }}
+                  >
+                    ({exchangeData.reviewCount})
+                  </Typography>
                 </Box>
                 <Divider sx={{ margin: "20px 0" }} />
                 <Grid container spacing={1} mt={2}>
@@ -385,33 +422,25 @@ const ItemDetail: React.FC = () => {
                         xs={4}
                         key={index}
                         onClick={() => router.push(item.url)}
-                        sx={{
-                          cursor: "pointer",
-                          "&:hover": {
-                            boxShadow: 2,
-                          },
-                        }}
+                        sx={{ cursor: "pointer", "&:hover": { boxShadow: 2 } }}
                       >
-                        {/* 이미지를 담는 Box */}
                         <Box
                           sx={{
                             position: "relative",
                             width: "100%",
                             height: 0,
-                            paddingBottom: "75%", // 비율을 조정하는 부분 (예: 4:3 비율)
-                            overflow: "hidden", // 넘치는 부분을 숨김
-                            borderRadius: "4px", // 모서리 둥글게
+                            paddingBottom: "75%",
+                            overflow: "hidden",
+                            borderRadius: "4px",
                           }}
                         >
                           <Image
                             src={item.imageUrl || DEFAULT_IMAGE}
                             alt={item.title}
-                            layout="fill" // 부모 Box를 가득 채움
-                            objectFit="cover" // 이미지를 Box에 꽉 채우되 비율 유지
+                            layout="fill"
+                            objectFit="cover"
                           />
                         </Box>
-
-                        {/* 제목 및 가격 정보 */}
                         <Typography
                           variant="caption"
                           display="block"
@@ -437,7 +466,7 @@ const ItemDetail: React.FC = () => {
               </Paper>
             </Grid>
 
-            {/* Delete Confirmation Modal */}
+            {/* 삭제 확인 모달 */}
             <Modal open={openModal} onClose={() => setOpenModal(false)}>
               <Box
                 sx={{

--- a/src/main/java/org/example/spring/controller/ExchangeLikeController.java
+++ b/src/main/java/org/example/spring/controller/ExchangeLikeController.java
@@ -1,7 +1,5 @@
 package org.example.spring.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
 import org.example.spring.common.ApiResponseDto;
 import org.example.spring.domain.like.dto.AddLikeRequest;
 import org.example.spring.service.ExchangeLikeService;
@@ -12,6 +10,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
 /**
  * 중고 거래 게시글의 좋아요 기능을 처리하는 컨트롤러 클래스입니다.
  * 이 컨트롤러는 Exchange 시스템에서 좋아요를 관리하는 엔드포인트를 제공합니다.
@@ -20,23 +21,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/likes")
 @RequiredArgsConstructor
 public class ExchangeLikeController {
-    private final ExchangeLikeService exchangeLikeService;
-    /**
-     * 중고 거래 게시글에 좋아요를 추가하거나 취소합니다.
-     * 이 엔드포인트는 사용자가 중고 거래 게시글에 대한 좋아요 상태를 토글할 수 있게 합니다.
-     * 이미 좋아요가 있는 경우 취소되고, 없는 경우 추가됩니다.
-     *
-     * @param request HTTP 요청 객체. 현재 사용자의 인증 정보를 포함하고 있습니다.
-     *                이 정보는 사용자 식별 및 권한 확인에 사용될 수 있습니다.
-     * @param addLikeRequest 좋아요를 추가할 게시글의 정보를 포함하는 요청 객체.
-     *                       이 객체에는 게시글 ID 등의 필요한 정보가 포함되어야 합니다.
-     * @return ResponseEntity<ApiResponseDto<Boolean>> 형태의 응답.
-     *         - HTTP 상태 코드 201 (CREATED)를 반환합니다.
-     *         - 응답 본문에는 작업 성공 여부(Boolean)와 성공 메시지가 포함됩니다.
-     */
-    @PostMapping
-    public ResponseEntity<ApiResponseDto<Boolean>> addLike(HttpServletRequest request, @RequestBody AddLikeRequest addLikeRequest) {
-        exchangeLikeService.addLike(request, addLikeRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseDto.success("좋아요 상태를 변경하였습니다.", true));
-    }
+	private final ExchangeLikeService exchangeLikeService;
+
+	/**
+	 * 중고 거래 게시글에 좋아요를 추가하거나 취소합니다.
+	 * 이 엔드포인트는 사용자가 중고 거래 게시글에 대한 좋아요 상태를 토글할 수 있게 합니다.
+	 * 이미 좋아요가 있는 경우 취소되고, 없는 경우 추가됩니다.
+	 *
+	 * @param request HTTP 요청 객체. 현재 사용자의 인증 정보를 포함하고 있습니다.
+	 *                이 정보는 사용자 식별 및 권한 확인에 사용될 수 있습니다.
+	 * @param addLikeRequest 좋아요를 추가할 게시글의 정보를 포함하는 요청 객체.
+	 *                       이 객체에는 게시글 ID 등의 필요한 정보가 포함되어야 합니다.
+	 * @return ResponseEntity<ApiResponseDto < Boolean>> 형태의 응답.
+	 *         - HTTP 상태 코드 201 (CREATED)를 반환합니다.
+	 *         - 응답 본문에는 작업 성공 여부(Boolean)와 성공 메시지가 포함됩니다.
+	 */
+	@PostMapping
+	public ResponseEntity<ApiResponseDto<Boolean>> addLike(HttpServletRequest request,
+		@RequestBody AddLikeRequest addLikeRequest) {
+		boolean result = exchangeLikeService.addLike(request, addLikeRequest);
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseDto.success("좋아요 상태를 변경하였습니다.", result));
+	}
 }

--- a/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
+++ b/src/main/java/org/example/spring/domain/exchange/dto/ExchangeDetailResponseDto.java
@@ -9,9 +9,10 @@ import org.example.spring.constants.SalesStatus;
 import org.example.spring.domain.exchange.Exchange;
 import org.example.spring.domain.exchangeImage.dto.ExchangeImageResponseDto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Builder;
 import lombok.Getter;
-import org.example.spring.domain.reviewOverview.ReviewOverview;
 
 @Getter
 @Builder
@@ -30,9 +31,12 @@ public class ExchangeDetailResponseDto {
 	private final long reviewCount;
 	private final double average;
 	private final long likeCount;
+	@JsonProperty("isLike")
+	private final boolean isLike;
 
 	public static ExchangeDetailResponseDto fromExchange(Exchange exchange,
-		List<ExchangeNavigationResponseDto> recentExchangesByMember, boolean isWriter, long reviewCount, double average, long likeCount) {
+		List<ExchangeNavigationResponseDto> recentExchangesByMember, boolean isWriter, long reviewCount, double average,
+		long likeCount, boolean isLike) {
 		List<ExchangeImageResponseDto> images = new ArrayList<>();
 		if (!exchange.getImages().isEmpty()) {
 			images = exchange.getImages()
@@ -56,6 +60,7 @@ public class ExchangeDetailResponseDto {
 			.reviewCount(reviewCount)
 			.average(average)
 			.likeCount(likeCount)
+			.isLike(isLike)
 			.build();
 	}
 }

--- a/src/main/java/org/example/spring/domain/like/ExchangeLike.java
+++ b/src/main/java/org/example/spring/domain/like/ExchangeLike.java
@@ -1,5 +1,10 @@
 package org.example.spring.domain.like;
 
+import java.sql.Timestamp;
+
+import org.example.spring.domain.exchange.Exchange;
+import org.example.spring.domain.member.Member;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,14 +14,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.sql.Timestamp;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.spring.domain.exchange.Exchange;
-import org.example.spring.domain.member.Member;
 
 @Entity
 @Table(name = "exchange_like")
@@ -25,42 +27,44 @@ import org.example.spring.domain.member.Member;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExchangeLike {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "like_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "like_id")
+	private Long id;
 
-    @JoinColumn(name = "exchange_id", nullable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Exchange exchange;
+	@JoinColumn(name = "exchange_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Exchange exchange;
 
-    @JoinColumn(name = "member_id", nullable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+	@JoinColumn(name = "member_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
 
-    @Column(name = "created_at", nullable = false)
-    private Timestamp createdAt;
+	@Column(name = "created_at", nullable = false)
+	private Timestamp createdAt;
 
-    @Column(name = "canceled_at")
-    private Timestamp canceledAt;
+	@Column(name = "canceled_at")
+	private Timestamp canceledAt;
 
-    /**
-     * 좋아요 상태를 토글합니다.
-     *
-     * <ul>
-     *   <li>좋아요가 활성 상태인 경우 (canceledAt이 null인 경우), 좋아요를 취소합니다.</li>
-     *   <li>좋아요가 취소된 상태인 경우 (canceledAt이 null이 아닌 경우), 좋아요를 다시 활성화합니다.</li>
-     * </ul>
-     *
-     * <p>좋아요 취소 시, 현재 시간을 canceledAt에 기록합니다.</p>
-     * <p>좋아요 재활성화 시, canceledAt을 null로 설정하고 createdAt을 현재 시간으로 업데이트합니다.</p>
-     */
-    public void toggleLike() {
-        if (this.canceledAt == null) {
-            this.canceledAt = new Timestamp(System.currentTimeMillis());
-        } else {
-            this.canceledAt = null;
-            this.createdAt = new Timestamp(System.currentTimeMillis());
-        }
-    }
+	/**
+	 * 좋아요 상태를 토글합니다.
+	 *
+	 * <ul>
+	 *   <li>좋아요가 활성 상태인 경우 (canceledAt이 null인 경우), 좋아요를 취소합니다.</li>
+	 *   <li>좋아요가 취소된 상태인 경우 (canceledAt이 null이 아닌 경우), 좋아요를 다시 활성화합니다.</li>
+	 * </ul>
+	 *
+	 * <p>좋아요 취소 시, 현재 시간을 canceledAt에 기록합니다.</p>
+	 * <p>좋아요 재활성화 시, canceledAt을 null로 설정하고 createdAt을 현재 시간으로 업데이트합니다.</p>
+	 */
+	public boolean toggleLike() {
+		if (this.canceledAt == null) {
+			this.canceledAt = new Timestamp(System.currentTimeMillis());
+			return false;
+		} else {
+			this.canceledAt = null;
+			this.createdAt = new Timestamp(System.currentTimeMillis());
+			return true;
+		}
+	}
 }

--- a/src/main/java/org/example/spring/service/ExchangeLikeService.java
+++ b/src/main/java/org/example/spring/service/ExchangeLikeService.java
@@ -1,8 +1,7 @@
 package org.example.spring.service;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.sql.Timestamp;
-import lombok.RequiredArgsConstructor;
+
 import org.example.spring.domain.exchange.Exchange;
 import org.example.spring.domain.like.ExchangeLike;
 import org.example.spring.domain.like.dto.AddLikeRequest;
@@ -13,6 +12,9 @@ import org.example.spring.security.jwt.JwtTokenValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
 /**
  * 중고 거래 게시글에 대한 좋아요 기능을 처리하는 서비스 클래스입니다.
  * 이 클래스는 좋아요 추가 및 삭제와 관련된 비즈니스 로직을 구현합니다.
@@ -20,54 +22,58 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ExchangeLikeService {
-    private final ExchangeLikeRepository exchangeLikeRepository;
-    private final ExchangeRepository exchangeRepository;
-    private final JwtTokenValidator jwtTokenValidator;
+	private final ExchangeLikeRepository exchangeLikeRepository;
+	private final ExchangeRepository exchangeRepository;
+	private final JwtTokenValidator jwtTokenValidator;
 
-    /**
-     * HTTP 요청으로부터 인증된 사용자 정보를 추출합니다.
-     *
-     * @param request           HTTP 요청 객체
-     * @return                  인증된 Member 객체
-     * @throws RuntimeException 토큰이 유효하지 않거나 사용자를 찾을 수 없는 경우
-     */
-    private Member getAuthenticatedMember(HttpServletRequest request) {
-        String token = jwtTokenValidator.extractTokenFromHeader(request);
-        return jwtTokenValidator.validateTokenAndGetMember(token);
-    }
+	/**
+	 * HTTP 요청으로부터 인증된 사용자 정보를 추출합니다.
+	 *
+	 * @param request           HTTP 요청 객체
+	 * @return 인증된 Member 객체
+	 * @throws RuntimeException 토큰이 유효하지 않거나 사용자를 찾을 수 없는 경우
+	 */
+	private Member getAuthenticatedMember(HttpServletRequest request) {
+		String token = jwtTokenValidator.extractTokenFromHeader(request);
+		return jwtTokenValidator.validateTokenAndGetMember(token);
+	}
 
-    /**
-     * 중고 거래 게시글에 대한 좋아요를 추가하거나 상태를 변경합니다.
-     * 이미 좋아요가 존재하는 경우 상태를 토글하고, 존재하지 않는 경우 새로 추가합니다.
-     *
-     * @param request HTTP 요청 객체. 사용자 인증 정보를 포함합니다.
-     * @param addLikeRequest 좋아요 추가 요청 DTO. 좋아요를 추가할 중고 거래 게시글의 ID를 포함합니다.
-     * @return 좋아요 처리 결과. 성공적으로 처리된 경우 true를 반환합니다.
-     */
-    @Transactional
-    public boolean addLike(HttpServletRequest request, AddLikeRequest addLikeRequest) {
-        Member member = getAuthenticatedMember(request);
+	/**
+	 * 중고 거래 게시글에 대한 좋아요를 추가하거나 상태를 변경합니다.
+	 * 이미 좋아요가 존재하는 경우 상태를 토글하고, 존재하지 않는 경우 새로 추가합니다.
+	 *
+	 * @param request HTTP 요청 객체. 사용자 인증 정보를 포함합니다.
+	 * @param addLikeRequest 좋아요 추가 요청 DTO. 좋아요를 추가할 중고 거래 게시글의 ID를 포함합니다.
+	 * @return 좋아요 처리 결과. 성공적으로 처리된 경우 true를 반환합니다.
+	 */
+	@Transactional
+	public boolean addLike(HttpServletRequest request, AddLikeRequest addLikeRequest) {
+		Member member = getAuthenticatedMember(request);
 
-        Exchange exchange = exchangeRepository.findById(addLikeRequest.getExchangeId()).orElseThrow(() -> new RuntimeException("교환 거래를 찾을 수 없습니다."));
+		Exchange exchange = exchangeRepository.findById(addLikeRequest.getExchangeId())
+			.orElseThrow(() -> new RuntimeException("교환 거래를 찾을 수 없습니다."));
 
-        ExchangeLike existingLike = exchangeLikeRepository.findByExchangeAndMember(exchange, member).orElse(null);
+		ExchangeLike existingLike = exchangeLikeRepository.findByExchangeAndMember(exchange, member).orElse(null);
 
-        if (existingLike != null) {
-            if (existingLike.getCanceledAt() == null) {
-                existingLike.toggleLike();
-            } else {
-                existingLike.toggleLike();
-            }
-            exchangeLikeRepository.save(existingLike);
-        } else {
-            ExchangeLike newLike = ExchangeLike.builder()
-                .exchange(exchange)
-                .member(member)
-                .createdAt(new Timestamp(System.currentTimeMillis()))
-                .build();
-            exchangeLikeRepository.save(newLike);
-        }
+		boolean isLike = false;
 
-        return true;
-    }
+		if (existingLike != null) {
+			if (existingLike.getCanceledAt() == null) {
+				isLike = existingLike.toggleLike();
+			} else {
+				isLike = existingLike.toggleLike();
+			}
+			exchangeLikeRepository.save(existingLike);
+		} else {
+			ExchangeLike newLike = ExchangeLike.builder()
+				.exchange(exchange)
+				.member(member)
+				.createdAt(new Timestamp(System.currentTimeMillis()))
+				.build();
+			exchangeLikeRepository.save(newLike);
+			isLike = true;
+		}
+
+		return isLike;
+	}
 }


### PR DESCRIPTION
## 📝 PR 설명
게시물 상세 페이지 내부에 좋아요 영역 추가와, API 연동을 완료했습니다.
<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- ✨ 좋아요 기능이 추가됩니다. 눌러서 통신이 가능하며, 좋아요 개수는 하루에 1번 업데이트 됩니다.
- ✨ 좋아요 관련 BE API 리팩토링 및 기능 추가

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [ ] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #254
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 자체 코드 리뷰를 수행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->