### PR TITLE
Fix: 비로그인 시 상세조회 페이지 버그 수정, 게시물 수정 시 기존 이미지 삭제되도록 변경

### DIFF
--- a/fe/play-baseball-fe/pages/exchange/write/[id].tsx
+++ b/fe/play-baseball-fe/pages/exchange/write/[id].tsx
@@ -59,7 +59,7 @@ const EditPostForm = () => {
           setPrice(price);
           setContent(content);
           setStatus(status as ExchangeStatus);
-          setImages(images); // 서버로부터 받은 이미지들 (ImageData 형식)
+          // setImages(images); // 서버로부터 받은 이미지들 (ImageData 형식)
         } catch (error) {
           console.error("Error fetching post data:", error);
         }


### PR DESCRIPTION
## 📝 PR 설명
게시물 상세조회 시 토큰을 검증하는 로직에서 null 관련 예외 처리가 되어있지 않아 이를 수정합니다.
게시물 수정 시 기존 이미지 재등록 관련 오류가 있어 수정 시에는 기존 이미지를 모두 삭제하도록 변경합니다.

<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->

- 🐛 게시물 상세 조회 시 토큰이 없을 경우 예외처리가 가능하도록 수정
- 🐛 게시물 수정 시 기존 이미지 자체를 프론트에서도 버려지게 보이도록 수정

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #270
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->