### PR TITLE
Fix: 게시물 등록, 수정시 새 제품 가격 로직 비동기 처리

### DIFF
--- a/fe/play-baseball-fe/pages/exchange/[id].tsx
+++ b/fe/play-baseball-fe/pages/exchange/[id].tsx
@@ -321,8 +321,9 @@ const ItemDetail: React.FC = () => {
                 </Typography>
                 <Divider sx={{ margin: "20px 0" }} />
                 <Typography variant="body1">
-                  이 상품의 정가는{" "}
-                  {exchangeData?.regularPrice?.toLocaleString() || "0"}원입니다.
+                  {exchangeData?.regularPrice === 0
+                    ? "현재 앨런이 상품 가격을 탐색 중입니다."
+                    : `앨런이 찾은 이 상품의 새 제품 가격은 ${exchangeData?.regularPrice?.toLocaleString()}원입니다.`}
                 </Typography>
                 <Divider sx={{ margin: "20px 0" }} />
                 <Button variant="contained" fullWidth>

--- a/src/main/java/org/example/spring/Application.java
+++ b/src/main/java/org/example/spring/Application.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableAsync
 @EnableJpaAuditing
 @EnableScheduling
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)

--- a/src/main/java/org/example/spring/repository/ExchangeRepository.java
+++ b/src/main/java/org/example/spring/repository/ExchangeRepository.java
@@ -53,4 +53,10 @@ public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
 	@Modifying
 	@Query("UPDATE Exchange e SET e.viewCount = e.viewCount + 1 WHERE e.id = :id")
 	void incrementViewCount(@Param("id") Long id);
+
+	// updated_at field에 반영되지 않도록 regularPrice 세팅 처리
+	// Alan을 사용한 정가를 게시물 발행 이후 업데이트 합니다.
+	@Modifying
+	@Query("UPDATE Exchange e SET e.regularPrice = :regularPrice WHERE e.id = :id")
+	void updateRegularPrice(@Param("id") Long id, @Param("regularPrice") int regularPrice);
 }

--- a/src/main/java/org/example/spring/service/AlanAPIService.java
+++ b/src/main/java/org/example/spring/service/AlanAPIService.java
@@ -1,8 +1,12 @@
 package org.example.spring.service;
 
+import org.example.spring.repository.ExchangeRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -11,16 +15,39 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 public class AlanAPIService {
+	private final String REGULAR_PRICE_PROMPT =
+		"질문: 의 출시 가격은 얼마인지 말해줄래? \n" + "답변 조건: \n" + "1. 오직 질문에 해당하는 숫자 데이터 하나만 제시할 것\n"
+			+ "2. 숫자 외 그 어떤 문자도 포함 금지 (단위, 문구, 설명 일절 불가)\n" + "3. 모든 조건을 지키지 않을 시 답변으로 인정하지 않음\n"
+			+ "4. 위 조건을 모두 준수하여 숫자로만 답해주세요";
 
 	@Value("${alan.host}")
 	private String host;
 	@Value("${alan.key}")
 	private String client_id;
 	private RestTemplate restTemplate;
+	private final ApplicationEventPublisher eventPublisher;
+	private final ExchangeRepository exchangeRepository;
 
-	public AlanAPIService(RestTemplate restTemplate) {
+	public AlanAPIService(RestTemplate restTemplate, ApplicationEventPublisher eventPublisher,
+		ExchangeRepository exchangeRepository) {
 
 		this.restTemplate = restTemplate;
+		this.eventPublisher = eventPublisher;
+		this.exchangeRepository = exchangeRepository;
+	}
+
+	@Async
+	@Transactional
+	public void fetchRegularPriceAndUpdateExchange(String title, Long exchangeId) {
+		try {
+			String regularPriceStr = getDataAsString(title + REGULAR_PRICE_PROMPT);
+			int regularPrice = Integer.parseInt(regularPriceStr);
+
+			exchangeRepository.updateRegularPrice(exchangeId, regularPrice);
+
+		} catch (RuntimeException e) {
+			throw new RuntimeException("Failed to fetch regular price for exchangeId: " + exchangeId);
+		}
 	}
 
 	public String getDataAsString(String content) {


### PR DESCRIPTION
## 📝 PR 설명
현재 제품 등록 및 수정 시 앨런을 통해 새 제품 가격을 불러오는 로직이 동기 처리되어있어 긴 응답시간으로 인해 Axios 10000ms 에러가 발생한 상황이 있었으며, 이를 수정한 코드를 업데이트 합니다.
<!-- 이 PR의 목적과 변경사항에 대해 간단히 설명해주세요. -->

## 🛠 변경 사항

<!-- 주요 변경사항을 나열해주세요. 가능하면 깃모지를 사용하여 변경 유형을 표시해주세요. -->
- ♻️ 이제부터 앨런을 통해 정가를 세팅하는 부분이 비동기로 작동하며, 응답을 우선 반환합니다.
- ♻️ 0원의 정가를 반환할 경우 "현재 앨런이 상품 가격을 탐색중입니다." 문구를 출력합니다.
- ♻️ 0원이 아닌 정가를 반환할 경우 "앨런이 찾은 이 상품의 새 제품 가격은 {정가}원 입니다." 문구를 출력합니다.

## 🔍 테스트

<!-- 이 변경사항을 어떻게 테스트했는지 설명해주세요. -->

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 실행
- [x] 수동 테스트 수행

## 📸 스크린샷 (선택사항)

<!-- UI 변경사항이 있는 경우 전후 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
Relates to #283
<!-- 관련된 이슈 번호를 적어주세요. 예: "Closes #123" 또는 "Relates to #456" -->

## 📋 체크리스트

- [x] 코드 컨벤션을 준수했습니다.
- [x] 자체 코드 리뷰를 수행했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 새로운 종속성을 추가한 경우, 보안 검사를 수행했습니다.

## 📢 추가 코멘트

<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 추가 설명이 필요한 사항을 적어주세요. -->